### PR TITLE
Handling modular ADD and MUL

### DIFF
--- a/src/scalib_ext/scalib-py/src/belief_propagation.rs
+++ b/src/scalib_ext/scalib-py/src/belief_propagation.rs
@@ -62,12 +62,22 @@ pub fn to_func(function: &PyDict) -> Func {
     } else if func == 2 {
         let values: PyReadonlyArray1<u32> = function.get_item("values").unwrap().extract().unwrap();
         f = FuncType::XORCST(values.as_array().to_owned());
+    } else if func == 3 {
+        let table: PyReadonlyArray1<u32> = function.get_item("table").unwrap().extract().unwrap();
+        f = FuncType::LOOKUP(table.as_array().to_owned());
     } else if func == 4 {
         let values: PyReadonlyArray1<u32> = function.get_item("values").unwrap().extract().unwrap();
         f = FuncType::ANDCST(values.as_array().to_owned());
+    } else if func == 5 {
+        f = FuncType::ADD;
+    } else if func == 6 {
+        let values: PyReadonlyArray1<u32> = function.get_item("values").unwrap().extract().unwrap();
+        f = FuncType::ADDCST(values.as_array().to_owned());
+    } else if func == 7{
+        f = FuncType::MUL;
     } else {
-        let table: PyReadonlyArray1<u32> = function.get_item("table").unwrap().extract().unwrap();
-        f = FuncType::LOOKUP(table.as_array().to_owned());
+        let values: PyReadonlyArray1<u32> = function.get_item("values").unwrap().extract().unwrap();
+        f = FuncType::MULCST(values.as_array().to_owned());
     }
 
     Func {

--- a/src/scalib_ext/scalib/src/belief_propagation.rs
+++ b/src/scalib_ext/scalib/src/belief_propagation.rs
@@ -210,7 +210,7 @@ pub fn update_functions(functions: &[Func], edges: &mut [Vec<&mut Array2<f64>>])
                     .for_each_init(
                         || (Array1::zeros(nc), Array1::zeros(nc), Array1::zeros(nc)),
                         |(in1_msg_scratch, in2_msg_scratch, out_msg_scratch),
-                        (mut input1_msg, mut input2_msg, mut output_msg)| {
+                         (mut input1_msg, mut input2_msg, mut output_msg)| {
                             in1_msg_scratch.fill(0.0);
                             in2_msg_scratch.fill(0.0);
                             out_msg_scratch.fill(0.0);
@@ -243,7 +243,7 @@ pub fn update_functions(functions: &[Func], edges: &mut [Vec<&mut Array2<f64>>])
                     .for_each_init(
                         || (Array1::zeros(nc), Array1::zeros(nc), Array1::zeros(nc)),
                         |(in1_msg_scratch, in2_msg_scratch, out_msg_scratch),
-                        (mut input1_msg, mut input2_msg, mut output_msg)| {
+                         (mut input1_msg, mut input2_msg, mut output_msg)| {
                             in1_msg_scratch.fill(0.0);
                             in2_msg_scratch.fill(0.0);
                             out_msg_scratch.fill(0.0);

--- a/tests/test_sascagraph.py
+++ b/tests/test_sascagraph.py
@@ -101,6 +101,7 @@ def test_add_public():
 
     assert np.allclose(distri_y_ref, distri_y)
 
+
 def test_mul_public():
     """
     Test MUL with public data
@@ -132,6 +133,7 @@ def test_mul_public():
         distri_y_ref[np.arange(n), y] += distri_x[np.arange(n), x]
 
     assert np.allclose(distri_y_ref, distri_y)
+
 
 def test_xor_public():
     """
@@ -203,6 +205,7 @@ def test_AND():
     distri_z_ref = (distri_z_ref.T / np.sum(distri_z_ref, axis=1)).T
     assert np.allclose(distri_z_ref, distri_z)
 
+
 def test_ADD():
     """
     Test ADD between distributions
@@ -241,6 +244,7 @@ def test_ADD():
     distri_z_ref = (distri_z_ref.T / np.sum(distri_z_ref, axis=1)).T
     assert np.allclose(distri_z_ref, distri_z)
 
+
 def test_MUL():
     """
     Test MUL between distributions
@@ -278,6 +282,7 @@ def test_MUL():
 
     distri_z_ref = (distri_z_ref.T / np.sum(distri_z_ref, axis=1)).T
     assert np.allclose(distri_z_ref, distri_z)
+
 
 def test_xor():
     """

--- a/tests/test_sascagraph.py
+++ b/tests/test_sascagraph.py
@@ -69,6 +69,70 @@ def test_and_public():
     assert np.allclose(distri_y_ref, distri_y)
 
 
+def test_add_public():
+    """
+    Test ADD with public data
+    """
+    nc = 13
+    n = 100
+    public = np.random.randint(0, nc, n, dtype=np.uint32)
+    distri_x = np.random.randint(1, 100, (n, nc))
+    distri_x = (distri_x.T / np.sum(distri_x, axis=1)).T
+
+    graph = f"""
+        # some comments
+        NC {nc}
+        PROPERTY y = x + p
+        VAR MULTI y
+        VAR MULTI x
+        VAR MULTI p#come comments
+        """
+    graph = SASCAGraph(graph, n)
+    graph.set_public("p", public)
+    graph.set_init_distribution("x", distri_x)
+
+    graph.run_bp(1)
+
+    distri_y = graph.get_distribution("y")
+    distri_y_ref = np.zeros(distri_x.shape)
+    for x in range(nc):
+        y = (x + public) % nc
+        distri_y_ref[np.arange(n), y] += distri_x[np.arange(n), x]
+
+    assert np.allclose(distri_y_ref, distri_y)
+
+def test_mul_public():
+    """
+    Test MUL with public data
+    """
+    nc = 13
+    n = 100
+    public = np.random.randint(0, nc, n, dtype=np.uint32)
+    distri_x = np.random.randint(1, 100, (n, nc))
+    distri_x = (distri_x.T / np.sum(distri_x, axis=1)).T
+
+    graph = f"""
+        # some comments
+        NC {nc}
+        PROPERTY y = x * p
+        VAR MULTI y
+        VAR MULTI x
+        VAR MULTI p#come comments
+        """
+    graph = SASCAGraph(graph, n)
+    graph.set_public("p", public)
+    graph.set_init_distribution("x", distri_x)
+
+    graph.run_bp(1)
+
+    distri_y = graph.get_distribution("y")
+    distri_y_ref = np.zeros(distri_x.shape)
+    for x in range(nc):
+        y = (x * public) % nc
+        distri_y_ref[np.arange(n), y] += distri_x[np.arange(n), x]
+
+    assert np.allclose(distri_y_ref, distri_y)
+
 def test_xor_public():
     """
     Test XOR with public data
@@ -139,6 +203,81 @@ def test_AND():
     distri_z_ref = (distri_z_ref.T / np.sum(distri_z_ref, axis=1)).T
     assert np.allclose(distri_z_ref, distri_z)
 
+def test_ADD():
+    """
+    Test ADD between distributions
+    """
+    nc = 251
+    n = 4
+    distri_x = np.random.randint(1, 10000000, (n, nc))
+    distri_x = (distri_x.T / np.sum(distri_x, axis=1)).T
+    distri_y = np.random.randint(1, 10000000, (n, nc))
+    distri_y = (distri_y.T / np.sum(distri_y, axis=1)).T
+
+    graph = f"""
+        # some comments
+        NC {nc}
+        PROPERTY z = x+y
+        VAR MULTI z
+        VAR MULTI x
+        VAR MULTI y
+
+        """
+
+    graph = SASCAGraph(graph, n)
+    graph.set_init_distribution("x", distri_x)
+    graph.set_init_distribution("y", distri_y)
+
+    graph.run_bp(1)
+    distri_z = graph.get_distribution("z")
+
+    distri_z_ref = np.zeros(distri_z.shape)
+    msg = np.zeros(distri_z.shape)
+
+    for x in range(nc):
+        for y in range(nc):
+            distri_z_ref[:, (x + y) % nc] += distri_x[:, x] * distri_y[:, y]
+
+    distri_z_ref = (distri_z_ref.T / np.sum(distri_z_ref, axis=1)).T
+    assert np.allclose(distri_z_ref, distri_z)
+
+def test_MUL():
+    """
+    Test MUL between distributions
+    """
+    nc = 251
+    n = 4
+    distri_x = np.random.randint(1, 10000000, (n, nc))
+    distri_x = (distri_x.T / np.sum(distri_x, axis=1)).T
+    distri_y = np.random.randint(1, 10000000, (n, nc))
+    distri_y = (distri_y.T / np.sum(distri_y, axis=1)).T
+
+    graph = f"""
+        # some comments
+        NC {nc}
+        PROPERTY z = x*y
+        VAR MULTI z
+        VAR MULTI x
+        VAR MULTI y
+
+        """
+
+    graph = SASCAGraph(graph, n)
+    graph.set_init_distribution("x", distri_x)
+    graph.set_init_distribution("y", distri_y)
+
+    graph.run_bp(1)
+    distri_z = graph.get_distribution("z")
+
+    distri_z_ref = np.zeros(distri_z.shape)
+    msg = np.zeros(distri_z.shape)
+
+    for x in range(nc):
+        for y in range(nc):
+            distri_z_ref[:, (x * y) % nc] += distri_x[:, x] * distri_y[:, y]
+
+    distri_z_ref = (distri_z_ref.T / np.sum(distri_z_ref, axis=1)).T
+    assert np.allclose(distri_z_ref, distri_z)
 
 def test_xor():
     """


### PR DESCRIPTION
Currently, the function nodes handled in the BP graph are _logical_ operations. I locally added some _modular_ operations, namely `ADD` and `MUL` modulo `nc` the number of classes, along with some tests. 

Right now, the code runs, and complies with some unit tests similar to the ones provided in the repository. The added operations only handle two operands, like the bitwise `AND`. Nevertheless, it may be optimized in order for the `ADD` and `MUL` to handle more than two operands, and to run faster using FFT.

Regarding the convention of the operation codes in `sascagraph.py`, I arbitrarily chose numbers 5 to 8. I let you decide to change it or not.