### PR TITLE
SASCA: support modular ADD and MUL operations

### DIFF
--- a/src/scalib_ext/Cargo.lock
+++ b/src/scalib_ext/Cargo.lock
@@ -1125,7 +1125,7 @@ dependencies = [
  "bindgen",
  "cc",
  "itertools 0.10.0",
- "realfft",
+ "realfft 1.1.0",
 ]
 
 [[package]]
@@ -1165,7 +1165,16 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea97b8a9e985c85108699bf7884820cc90b8b8de6bbcbf4a8b44e5ae534ae0ce"
 dependencies = [
- "rustfft",
+ "rustfft 5.1.1",
+]
+
+[[package]]
+name = "realfft"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7695c87f31dc3644760f23fb59a3fed47659703abf76cf2d111f03b9e712342"
+dependencies = [
+ "rustfft 6.0.1",
 ]
 
 [[package]]
@@ -1233,6 +1242,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustfft"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d089e5c57521629a59f5f39bca7434849ff89bd6873b521afe389c1c602543"
+dependencies = [
+ "num-complex 0.4.0",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,10 +1291,13 @@ dependencies = [
  "ndarray-rand",
  "ndarray-stats",
  "nshare",
+ "num-complex 0.4.0",
  "num-integer",
  "numpy",
  "pyo3",
  "rayon",
+ "realfft 2.0.1",
+ "rustfft 6.0.1",
 ]
 
 [[package]]

--- a/src/scalib_ext/scalib-py/src/belief_propagation.rs
+++ b/src/scalib_ext/scalib-py/src/belief_propagation.rs
@@ -65,9 +65,18 @@ pub fn to_func(function: &PyDict) -> Func {
     } else if func == 4 {
         let values: PyReadonlyArray1<u32> = function.get_item("values").unwrap().extract().unwrap();
         f = FuncType::ANDCST(values.as_array().to_owned());
+    } else if func == 5 {
+        f = FuncType::ADD;
+    } else if func == 6 {
+        let values: PyReadonlyArray1<u32> = function.get_item("values").unwrap().extract().unwrap();
+        f = FuncType::ADDCST(values.as_array().to_owned());
+    } else if func == 7 {
+        f = FuncType::MUL;
+    } else if func == 8 {
+        let values: PyReadonlyArray1<u32> = function.get_item("values").unwrap().extract().unwrap();
+        f = FuncType::MULCST(values.as_array().to_owned());
     } else {
-        let table: PyReadonlyArray1<u32> = function.get_item("table").unwrap().extract().unwrap();
-        f = FuncType::LOOKUP(table.as_array().to_owned());
+        panic!("func {} value is not recognized", func);
     }
 
     Func {

--- a/src/scalib_ext/scalib-py/src/belief_propagation.rs
+++ b/src/scalib_ext/scalib-py/src/belief_propagation.rs
@@ -62,6 +62,9 @@ pub fn to_func(function: &PyDict) -> Func {
     } else if func == 2 {
         let values: PyReadonlyArray1<u32> = function.get_item("values").unwrap().extract().unwrap();
         f = FuncType::XORCST(values.as_array().to_owned());
+    } else if func == 3 {
+        let table: PyReadonlyArray1<u32> = function.get_item("table").unwrap().extract().unwrap();
+        f = FuncType::LOOKUP(table.as_array().to_owned());
     } else if func == 4 {
         let values: PyReadonlyArray1<u32> = function.get_item("values").unwrap().extract().unwrap();
         f = FuncType::ANDCST(values.as_array().to_owned());

--- a/src/scalib_ext/scalib/Cargo.toml
+++ b/src/scalib_ext/scalib/Cargo.toml
@@ -30,6 +30,10 @@ blis-sys = { git="https://github.com/cassiersg/blis-sys", optional = true }
 matrixmultiply = "0.3.1"
 hytra = "0.1.2"
 crossbeam-utils = "0.8.3"
+realfft = "2.0.1"
+rustfft = "6.0.0"
+num-complex = "0.4.0"
+
 
 [profile.release]
 debug = true

--- a/src/scalib_ext/scalib/src/belief_propagation.rs
+++ b/src/scalib_ext/scalib/src/belief_propagation.rs
@@ -53,10 +53,18 @@ pub enum FuncType {
     AND,
     /// Bitwise XOR of variables
     XOR,
+    /// Modular ADD of variables
+    ADD,
+    /// Modular MUL of variables
+    MUL,
     /// Bitwise XOR of variables, XORing additionally a public variable.
     XORCST(Array1<u32>),
     /// Bitwise AND of variables, ANDing additionally a public variable.
     ANDCST(Array1<u32>),
+    /// Modular ADD of variables, ADDing additionally a public variable.
+    ADDCST(Array1<u32>),
+    /// Modular MUL of variables, MULing additionally a public variable.
+    MULCST(Array1<u32>),
     /// Lookup table function.
     LOOKUP(Array1<u32>),
 }

--- a/src/scalib_ext/scalib/src/belief_propagation.rs
+++ b/src/scalib_ext/scalib/src/belief_propagation.rs
@@ -11,6 +11,8 @@
 use indicatif::{ProgressBar, ProgressFinish, ProgressIterator, ProgressStyle};
 use ndarray::{s, Array1, Array2, Axis};
 use rayon::prelude::*;
+use realfft::RealFftPlanner;
+use rustfft::num_complex::Complex;
 use std::convert::TryInto;
 
 /// Statistical distribution of a Para node.
@@ -189,7 +191,7 @@ pub fn update_functions(functions: &[Func], edges: &mut [Vec<&mut Array2<f64>>])
         .par_iter()
         .zip(edges.par_iter_mut())
         .for_each(|(function, edge)| match &function.functype {
-            FuncType::AND => {
+            FuncType::AND | FuncType::MUL => {
                 let [output_msg, input1_msg, input2_msg]: &mut [_; 3] =
                     edge.as_mut_slice().try_into().unwrap();
                 let nc = input1_msg.shape()[1];
@@ -211,7 +213,14 @@ pub fn update_functions(functions: &[Func], edges: &mut [Vec<&mut Array2<f64>>])
 
                             for i1 in 0..nc {
                                 for i2 in 0..nc {
-                                    let o: usize = i1 & i2;
+                                    // Unifies operators that can only be binary
+                                    let o = match &function.functype {
+                                        FuncType::AND => i1 & i2,
+                                        FuncType::MUL => {
+                                            (((i1 * i2) as u32) % (nc as u32)) as usize
+                                        }
+                                        _ => unreachable!(),
+                                    };
                                     in1_msg_scratch[i1] += input2_msg[i2] * output_msg[o];
                                     in2_msg_scratch[i2] += input1_msg[i1] * output_msg[o];
                                     out_msg_scratch[o] += input1_msg[i1] * input2_msg[i2];
@@ -223,10 +232,16 @@ pub fn update_functions(functions: &[Func], edges: &mut [Vec<&mut Array2<f64>>])
                         },
                     );
             }
+            FuncType::ADD => {
+                adds(edge.as_mut());
+            }
             FuncType::XOR => {
                 xors(edge.as_mut());
             }
-            FuncType::XORCST(values) => {
+            FuncType::XORCST(values)
+            | FuncType::ANDCST(values)
+            | FuncType::ADDCST(values)
+            | FuncType::MULCST(values) => {
                 let [output_msg, input1_msg]: &mut [_; 2] = edge.as_mut_slice().try_into().unwrap();
                 let nc = input1_msg.shape()[1];
                 (
@@ -243,33 +258,17 @@ pub fn update_functions(functions: &[Func], edges: &mut [Vec<&mut Array2<f64>>])
                             out_msg_scratch.fill(0.0);
                             let value = value.first().unwrap();
                             for i1 in 0..nc {
-                                let o: usize = ((i1 as u32) ^ value) as usize;
-                                in1_msg_scratch[i1] += output_msg[o];
-                                out_msg_scratch[o] += input1_msg[i1];
-                            }
-                            input1_msg.assign(in1_msg_scratch);
-                            output_msg.assign(out_msg_scratch);
-                        },
-                    );
-            }
-            FuncType::ANDCST(values) => {
-                let [output_msg, input1_msg]: &mut [_; 2] = edge.as_mut_slice().try_into().unwrap();
-                let nc = input1_msg.shape()[1];
-                (
-                    input1_msg.outer_iter_mut(),
-                    output_msg.outer_iter_mut(),
-                    values.outer_iter(),
-                )
-                    .into_par_iter()
-                    .for_each_init(
-                        || (Array1::zeros(nc), Array1::zeros(nc)),
-                        |(in1_msg_scratch, out_msg_scratch),
-                         (mut input1_msg, mut output_msg, value)| {
-                            in1_msg_scratch.fill(0.0);
-                            out_msg_scratch.fill(0.0);
-                            let value = value.first().unwrap();
-                            for i1 in 0..nc {
-                                let o: usize = ((i1 as u32) & value) as usize;
+                                let o: usize = match &function.functype {
+                                    FuncType::XORCST(values) => ((i1 as u32) ^ value) as usize,
+                                    FuncType::ANDCST(values) => ((i1 as u32) & value) as usize,
+                                    FuncType::ADDCST(values) => {
+                                        (((i1 as u32) + value) % (nc as u32)) as usize
+                                    }
+                                    FuncType::MULCST(values) => {
+                                        (((i1 as u32) * value) % (nc as u32)) as usize
+                                    }
+                                    _ => unreachable!(),
+                                };
                                 in1_msg_scratch[i1] += output_msg[o];
                                 out_msg_scratch[o] += input1_msg[i1];
                             }
@@ -302,6 +301,57 @@ pub fn update_functions(functions: &[Func], edges: &mut [Vec<&mut Array2<f64>>])
                     );
             }
         });
+}
+
+pub fn adds(inputs: &mut [&mut Array2<f64>]) {
+    let n_runs = inputs[0].shape()[0];
+    let nc = inputs[0].shape()[1];
+
+    // Sets the FFT operator
+    let mut real_planner = RealFftPlanner::<f64>::new();
+    let r2c = real_planner.plan_fft_forward(nc);
+    let c2r = real_planner.plan_fft_inverse(nc);
+
+    for run in 0..n_runs {
+        let mut spectrums: Vec<Array1<Complex<f64>>> = Vec::new();
+        let mut acc = Array1::<Complex<f64>>::ones(nc / 2 + 1);
+        inputs.iter_mut().for_each(|input| {
+            let mut input = input.slice_mut(s![run, ..]);
+            let input_fft_s = input.as_slice_mut().unwrap();
+            let mut spectrum = Array1::<Complex<f64>>::zeros(nc / 2 + 1);
+            let spec = spectrum.as_slice_mut().unwrap();
+            // Computes the FFT
+            r2c.process(input_fft_s, spec).unwrap();
+            // Clips the transformed
+            spectrum.mapv_inplace(|x| {
+                if x.norm_sqr() == 0.0 {
+                    Complex::new(MIN_PROBA, MIN_PROBA)
+                } else {
+                    x
+                }
+            });
+            spectrums.push(spectrum);
+            // Accumulates through the operands
+            acc.zip_mut_with(&spectrums[spectrums.len() - 1], |x, y| *x = *x * y);
+            acc /= acc.sum();
+        });
+        assert_eq!(inputs.len(), spectrums.len());
+        // Invert accumulation input_wise and invert transform.
+        spectrums
+            .iter_mut()
+            .zip(inputs.iter_mut())
+            .for_each(|(spectrum, input)| {
+                let mut input = input.slice_mut(s![run, ..]);
+                spectrum.zip_mut_with(&acc, |x, y| *x = *y / *x);
+                let input_fft_s = input.as_slice_mut().unwrap();
+                let spec = spectrum.as_slice_mut().unwrap();
+                c2r.process(spec, input_fft_s).unwrap();
+                make_non_zero(&mut input);
+                let s = input.sum();
+                input /= s;
+                make_non_zero(&mut input);
+            });
+    }
 }
 
 /// Compute a XOR function node between all edges.

--- a/src/scalib_ext/scalib/src/belief_propagation.rs
+++ b/src/scalib_ext/scalib/src/belief_propagation.rs
@@ -199,6 +199,8 @@ pub fn update_functions(functions: &[Func], edges: &mut [Vec<&mut Array2<f64>>])
         .par_iter()
         .zip(edges.par_iter_mut())
         .for_each(|(function, edge)| match &function.functype {
+            // TODO: if nc is prime, the update for MUL can be computed more efficiently by mapping
+            // classes to their discrete logarithm, and by applying FFT.
             FuncType::AND | FuncType::MUL => {
                 let [output_msg, input1_msg, input2_msg]: &mut [_; 3] =
                     edge.as_mut_slice().try_into().unwrap();
@@ -311,6 +313,7 @@ pub fn update_functions(functions: &[Func], edges: &mut [Vec<&mut Array2<f64>>])
         });
 }
 
+/// Compute an ADD function node between all edges.
 pub fn adds(inputs: &mut [&mut Array2<f64>]) {
     let n_runs = inputs[0].shape()[0];
     let nc = inputs[0].shape()[1];

--- a/tests/test_sascagraph.py
+++ b/tests/test_sascagraph.py
@@ -140,6 +140,129 @@ def test_AND():
     assert np.allclose(distri_z_ref, distri_z)
 
 
+def test_ADD():
+    """
+    Test ADD between distributions
+    """
+    nc = 251
+    n = 4
+    distri_x = np.random.randint(1, 10000000, (n, nc))
+    distri_x = (distri_x.T / np.sum(distri_x, axis=1)).T
+    distri_y = np.random.randint(1, 10000000, (n, nc))
+    distri_y = (distri_y.T / np.sum(distri_y, axis=1)).T
+
+    graph = f"""
+        # some comments
+        NC {nc}
+        PROPERTY z = x+y
+        VAR MULTI z
+        VAR MULTI x
+        VAR MULTI y
+
+        """
+
+    graph = SASCAGraph(graph, n)
+    graph.set_init_distribution("x", distri_x)
+    graph.set_init_distribution("y", distri_y)
+
+    graph.run_bp(1)
+    distri_z = graph.get_distribution("z")
+
+    distri_z_ref = np.zeros(distri_z.shape)
+    msg = np.zeros(distri_z.shape)
+
+    for x in range(nc):
+        for y in range(nc):
+            distri_z_ref[:, (x + y) % nc] += distri_x[:, x] * distri_y[:, y]
+
+    distri_z_ref = (distri_z_ref.T / np.sum(distri_z_ref, axis=1)).T
+    assert np.allclose(distri_z_ref, distri_z)
+
+
+def test_ADD_multiple():
+    """
+    Test ADD between distributions
+    """
+    nc = 17
+    n = 4
+    distri_x = np.random.randint(1, 10000000, (n, nc))
+    distri_x = (distri_x.T / np.sum(distri_x, axis=1)).T
+    distri_y = np.random.randint(1, 10000000, (n, nc))
+    distri_y = (distri_y.T / np.sum(distri_y, axis=1)).T
+    distri_w = np.random.randint(1, 10000000, (n, nc))
+    distri_w = (distri_w.T / np.sum(distri_w, axis=1)).T
+
+    graph = f"""
+        # some comments
+        NC {nc}
+        PROPERTY z = x+y+w
+        VAR MULTI z
+        VAR MULTI x
+        VAR MULTI y
+        VAR MULTI w
+        """
+
+    graph = SASCAGraph(graph, n)
+    graph.set_init_distribution("x", distri_x)
+    graph.set_init_distribution("y", distri_y)
+    graph.set_init_distribution("w", distri_w)
+
+    graph.run_bp(1)
+    distri_z = graph.get_distribution("z")
+
+    distri_z_ref = np.zeros(distri_z.shape)
+    msg = np.zeros(distri_z.shape)
+
+    for x in range(nc):
+        for y in range(nc):
+            for w in range(nc):
+                distri_z_ref[:, (x + y + w) % nc] += (
+                    distri_x[:, x] * distri_y[:, y] * distri_w[:, w]
+                )
+
+    distri_z_ref = (distri_z_ref.T / np.sum(distri_z_ref, axis=1)).T
+    assert np.allclose(distri_z_ref, distri_z)
+
+
+def test_MUL():
+    """
+    Test MUL between distributions
+    """
+    nc = 251
+    n = 4
+    distri_x = np.random.randint(1, 10000000, (n, nc))
+    distri_x = (distri_x.T / np.sum(distri_x, axis=1)).T
+    distri_y = np.random.randint(1, 10000000, (n, nc))
+    distri_y = (distri_y.T / np.sum(distri_y, axis=1)).T
+
+    graph = f"""
+        # some comments
+        NC {nc}
+        PROPERTY z = x*y
+        VAR MULTI z
+        VAR MULTI x
+        VAR MULTI y
+
+        """
+
+    graph = SASCAGraph(graph, n)
+    graph.set_init_distribution("x", distri_x)
+    graph.set_init_distribution("y", distri_y)
+
+    graph.run_bp(1)
+    distri_z = graph.get_distribution("z")
+
+    distri_z_ref = np.zeros(distri_z.shape)
+    msg = np.zeros(distri_z.shape)
+
+    for x in range(nc):
+        for y in range(nc):
+            distri_z_ref[:, (x * y) % nc] += distri_x[:, x] * distri_y[:, y]
+
+    distri_z_ref = (distri_z_ref.T / np.sum(distri_z_ref, axis=1)).T
+    assert np.allclose(distri_z_ref, distri_z)
+
+
 def test_xor():
     """
     Test XOR between distributions


### PR DESCRIPTION
@cassiersg 's suggestion have been taken into account. 

Regarding the dictionary mapping the operators in `src/scalib/attacks/sascagraph.py`, I separated operators only working as binary operators (`AND`, `MUL`) and those who can work a n-ary operators (n >= 2) (`ADD`, `XOR`).

**Further improvements:** if nc is prime, the pass across `MUL` can be implemented more efficiently, by mapping non-zero classes to their discrete log, and by applying the FFT (like in an `ADD` node).