### PR TITLE
Handle SIGINT when running native code.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 Not released
 ------------
 
+* Allow all computations to be interrupted with Ctrl-C.
 * Fix deadlock when there is an error in large SNR computations (i.e., when n_vars*n_samples*n_traces > 2**33).
 * Allow LDA to behave like simple pooled gaussian templates (#22)
 * Refresh build system (Tox version 4, improved CI).

--- a/src/scalib/attacks/sascagraph.py
+++ b/src/scalib/attacks/sascagraph.py
@@ -1,7 +1,10 @@
-import numpy as np
 from functools import reduce
+
+import numpy as np
+
 from scalib import _scalib_ext
 from scalib.config.threading import _get_threadpool
+import scalib.utils
 
 
 class SASCAGraph:
@@ -236,16 +239,17 @@ class SASCAGraph:
         if self.solved_:
             raise Exception("Cannot run bp twice on a graph.")
         self._init_graph()
-        _scalib_ext.run_bp(
-            self.properties_,
-            [self.var_[x] for x in list(self.var_)],
-            it,
-            self.edge_,
-            self.nc_,
-            self.n_,
-            progress,
-            _get_threadpool(),
-        )
+        with scalib.utils.interruptible():
+            _scalib_ext.run_bp(
+                self.properties_,
+                [self.var_[x] for x in list(self.var_)],
+                it,
+                self.edge_,
+                self.nc_,
+                self.n_,
+                progress,
+                _get_threadpool(),
+            )
         self.solved_ = True
 
     def _share_edge(self, property, v):

--- a/src/scalib/config/threading.py
+++ b/src/scalib/config/threading.py
@@ -23,7 +23,7 @@ the system.
 Examples
 --------
 
-The used `ThreadPool` can also be defined directly in the python scripts. 
+The used `ThreadPool` can also be defined directly in the python scripts.
 
 >>> from scalib.config.threading import thread_context, ThreadPool
 >>> # Example 1: Set a default ThreadPool to 10 threads.
@@ -61,8 +61,10 @@ def thread_context(threads):
     """
     pool = _threads_as_pool(threads)
     restore_token = _thread_pool.set(pool)
-    yield pool
-    _thread_pool.reset(restore_token)
+    try:
+        yield pool
+    finally:
+        _thread_pool.reset(restore_token)
 
 
 def default_threadpool(threads):

--- a/src/scalib/metrics/snr.py
+++ b/src/scalib/metrics/snr.py
@@ -1,6 +1,8 @@
 import numpy as np
+
 from scalib import _scalib_ext
 from scalib.config.threading import _get_threadpool
+import scalib.utils
 
 SnrError = _scalib_ext.SnrError
 
@@ -99,8 +101,10 @@ class SNR:
         # _scalib_ext uses inverted axes for x.
         # we can copy when needed, as x should be small, so this should be cheap
         x = x.transpose().astype(np.uint16, order="C", casting="equiv", copy=False)
-        self._snr.update(l, x, _get_threadpool())
+        with scalib.utils.interruptible():
+            self._snr.update(l, x, _get_threadpool())
 
     def get_snr(self):
         r"""Return the current SNR estimation with an array of shape `(np,ns)`."""
-        return self._snr.get_snr(_get_threadpool())
+        with scalib.utils.interruptible():
+            return self._snr.get_snr(_get_threadpool())

--- a/src/scalib/metrics/ttest.py
+++ b/src/scalib/metrics/ttest.py
@@ -1,6 +1,8 @@
 import numpy as np
+
 from scalib import _scalib_ext
 from scalib.config.threading import _get_threadpool
+import scalib.utils
 
 
 class Ttest:
@@ -75,11 +77,13 @@ class Ttest:
         if not (nsl == self._ns):
             raise Exception(f"Expected second dim of l to have size {self._ns}.")
 
-        self._ttest.update(l, x, _get_threadpool())
+        with scalib.utils.interruptible():
+            self._ttest.update(l, x, _get_threadpool())
 
     def get_ttest(self):
         r"""Return the current Ttest estimation with an array of shape `(d,ns)`."""
-        return self._ttest.get_ttest(_get_threadpool())
+        with scalib.utils.interruptible():
+            return self._ttest.get_ttest(_get_threadpool())
 
 
 class MTtest:
@@ -150,7 +154,8 @@ class MTtest:
         if not (nx == nl):
             raise ValueError(f"Expected x with shape ({nl},)")
 
-        self._mttest.update(l, x, _get_threadpool())
+        with scalib.utils.interruptible():
+            self._mttest.update(l, x, _get_threadpool())
 
     def get_ttest(self):
         r"""Return the current MTtest estimation with an array of shape
@@ -158,4 +163,5 @@ class MTtest:
         `pois`.
 
         """
-        return self._mttest.get_ttest(_get_threadpool())
+        with scalib.utils.interruptible():
+            return self._mttest.get_ttest(_get_threadpool())

--- a/src/scalib/postprocessing/rankestimation.py
+++ b/src/scalib/postprocessing/rankestimation.py
@@ -39,6 +39,7 @@ import math
 
 from scalib import _scalib_ext
 from scalib.config.threading import _get_threadpool
+import scalib.utils
 
 
 def rank_nbin(costs, key, nbins, method="hist"):
@@ -71,9 +72,10 @@ def rank_nbin(costs, key, nbins, method="hist"):
             - **r** is the estimated key rank.
             - **rmax** is an upper bound for the key rank.
     """
-    return _scalib_ext.rank_nbin(
-        costs, key, nbins, _choose_merge_value(costs), method, _get_threadpool()
-    )
+    with scalib.utils.interruptible():
+        return _scalib_ext.rank_nbin(
+            costs, key, nbins, _choose_merge_value(costs), method, _get_threadpool()
+        )
 
 
 def rank_accuracy(costs, key, acc_bit=1.0, method="hist", max_nb_bin=2**26):
@@ -112,16 +114,16 @@ def rank_accuracy(costs, key, acc_bit=1.0, method="hist", max_nb_bin=2**26):
             - **r** is the estimated key rank.
             - **rmax** is an upper bound for the key rank.
     """
-
-    return _scalib_ext.rank_accuracy(
-        costs,
-        key,
-        2.0**acc_bit,
-        _choose_merge_value(costs),
-        method,
-        max_nb_bin,
-        _get_threadpool(),
-    )
+    with scalib.utils.interruptible():
+        return _scalib_ext.rank_accuracy(
+            costs,
+            key,
+            2.0**acc_bit,
+            _choose_merge_value(costs),
+            method,
+            max_nb_bin,
+            _get_threadpool(),
+        )
 
 
 def _choose_merge_value(costs):

--- a/src/scalib/utils.py
+++ b/src/scalib/utils.py
@@ -1,0 +1,28 @@
+"""
+Misc. internal SCALib utils.
+"""
+
+import contextlib
+import signal
+import threading
+
+
+@contextlib.contextmanager
+def interruptible():
+    """Replace current SIGINT handler with OS-default one.
+
+    This allows long-running non-python code (or multi-threaded one) to be
+    interrupted. This results in unclean python shutdown but it is better than
+    requiring to kill the process.
+
+    This is only feasable on the main thread. In other threads, this function
+    is a no-op.
+    """
+    if threading.current_thread() is threading.main_thread():
+        restore_sig = signal.signal(signal.SIGINT, signal.SIG_DFL)
+        try:
+            yield
+        finally:
+            signal.signal(signal.SIGINT, restore_sig)
+    else:
+        yield


### PR DESCRIPTION
Python has a fairly poor handling of SIGINT (Ctrl+C) in multi-threaded code.
The way we deal with it is to replace the python SIGINT handler with the OS default one (that kills the process) when running long computations implemented in native code.
The main drawback is that we get an impproper shutdown, but that should not be too much of an issue.

Fixes #12