### PR TITLE
Swith CPU feature detection to cpuinfo.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Not released
 * Fix deadlock when there is an error in large SNR computations (i.e., when n_vars*n_samples*n_traces > 2**33).
 * Allow LDA to behave like simple pooled gaussian templates (#22)
 * Refresh build system (Tox version 4, improved CI).
+* Not crash anymore on non x86-64 CPUs (no CI for those yet).
 
 v0.4.3 (2022/10/27)
 -------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ autodoc_mock_imports = [
         "scalib.version",
         "scalib.build_config",
         "numpy",
-        "cpufeature",
+        "cpuinfo",
         ]
 
 import sys

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ zip_safe = False
 python_requires = >=3.8
 install_requires =
         numpy~=1.19
+        py-cpuinfo~=9.0
         cpufeature~=0.2
 
 

--- a/src/scalib/__init__.py
+++ b/src/scalib/__init__.py
@@ -1,13 +1,14 @@
 __all__ = ["metrics", "attacks", "modeling", "postprocessing", "config"]
 
-import cpufeature
+import cpuinfo
 
 from .build_config import REQUIRE_AVX2
 from .version import version as __version__
 
-if REQUIRE_AVX2 and not (
-    cpufeature.CPUFeature["AVX2"] and cpufeature.CPUFeature["OS_AVX"]
-):
+cpu = cpuinfo.get_cpu_info()
+
+
+if REQUIRE_AVX2 and cpu["arch"] == "X68_64" and "avx2" not in cpu["flags"]:
     raise ImportError(
         "SCALib has been compiled with AVX2 instructions, which are not "
         + "supported by your CPU or OS. See "


### PR DESCRIPTION
cpufeatre was not maintained and crashing on non-x86 hardware.

Fixes #53