### PR TITLE
Add Dampening factor to Belief Propagation

### DIFF
--- a/src/scalib/attacks/factor_graph.py
+++ b/src/scalib/attacks/factor_graph.py
@@ -371,7 +371,7 @@ class BPState:
         for var in self._inner.graph().var_names():
             s.append(f"\tVar {var}")
             s.append(repr(self.get_distribution(var)))
-        s.append("FACTORS FROM VARS")
+        s.append("VARS TO FACTORS")
         for factor in self._inner.graph().factor_names():
             for var in self._inner.graph().factor_scope(factor):
                 s.append(f"\t{var} -> {factor}")

--- a/src/scalib/attacks/factor_graph.py
+++ b/src/scalib/attacks/factor_graph.py
@@ -169,11 +169,13 @@ class BPState:
         factor_graph: FactorGraph,
         nexec: int,
         public_values: Optional[ValsAssign] = None,
+        alpha: float = 0.0,
     ):
         if public_values is None:
             public_values = dict()
         self._fg = factor_graph
         self._inner = factor_graph._inner.new_bp(nexec, public_values)
+        self._alpha = alpha
 
     @property
     def fg(self) -> FactorGraph:
@@ -223,7 +225,7 @@ class BPState:
         """
         if initialize_states:
             self._inner.propagate_all_vars()
-        self._inner.propagate_loopy_step(it)
+        self._inner.propagate_loopy_step(it, self._alpha)
 
     def bp_acyclic(
         self,

--- a/src/scalib/attacks/factor_graph.py
+++ b/src/scalib/attacks/factor_graph.py
@@ -224,7 +224,7 @@ class BPState:
             Recommended after using :func:`BPState.set_evidence`.
         """
         if initialize_states:
-            self._inner.propagate_all_vars()
+            self._inner.propagate_all_vars(self._alpha)
         self._inner.propagate_loopy_step(it, self._alpha)
 
     def bp_acyclic(
@@ -346,7 +346,7 @@ class BPState:
             Identifier of the variable.
 
         """
-        return self._inner.propagate_var(var)
+        return self._inner.propagate_var(var, self._alpha)
 
     def propagate_factor(self, factor: str):
         """Run belief propagation on the given factor.

--- a/src/scalib/attacks/factor_graph.py
+++ b/src/scalib/attacks/factor_graph.py
@@ -226,6 +226,11 @@ class BPState:
         initialize_states:
             Whether to update variable distributions before running the BP iterations.
             Recommended after using :func:`BPState.set_evidence`.
+        alpha:
+            Dampening factor. When set to 0, dampening is disabled, otherwise a new message from a var -> factor is the weighted average of the current and previous message e.g. alpha*m_{v->f} + (1-alpha)*mprev_{v->f}
+            alpha must be in the interval [0.0, 1.0]. Default value is 0.
+        clear_beliefs:
+            Whether to clear beliefs between vars -> factors. Setting to False can help debugging. Default value is True.
         """
         if initialize_states:
             self._inner.propagate_all_vars(alpha, clear_beliefs)
@@ -348,6 +353,11 @@ class BPState:
         ----------
         var : string
             Identifier of the variable.
+        alpha:
+            Dampening factor. When set to 0, dampening is disabled, otherwise a new message from a var -> factor is the weighted average of the current and previous message e.g. alpha*m_{v->f} + (1-alpha)*mprev_{v->f}
+            alpha must be in the interval [0.0, 1.0]. Default value is 0.
+        clear_beliefs:
+            Whether to clear beliefs between vars -> factors. Setting to False can help debugging. Default value is True.
 
         """
         return self._inner.propagate_var(var, alpha, clear_beliefs)

--- a/src/scalib/attacks/factor_graph.py
+++ b/src/scalib/attacks/factor_graph.py
@@ -169,15 +169,11 @@ class BPState:
         factor_graph: FactorGraph,
         nexec: int,
         public_values: Optional[ValsAssign] = None,
-        alpha: float = 0.0,
-        clear_beliefs: bool = True,
     ):
         if public_values is None:
             public_values = dict()
         self._fg = factor_graph
         self._inner = factor_graph._inner.new_bp(nexec, public_values)
-        self._alpha = alpha
-        self._clear_beliefs = clear_beliefs
 
     @property
     def fg(self) -> FactorGraph:
@@ -201,7 +197,13 @@ class BPState:
         else:
             self._inner.set_evidence(var, distribution)
 
-    def bp_loopy(self, it: int, initialize_states: bool):
+    def bp_loopy(
+        self,
+        it: int,
+        initialize_states: bool,
+        alpha: float = 0.0,
+        clear_beliefs: bool = True,
+    ):
         """Runs belief propagation algorithm on the current state of the graph.
 
         This is a shortcut for calls to :meth:`propagate_var` and :meth:`propagate_factor`. It is equivalent to:
@@ -226,8 +228,8 @@ class BPState:
             Recommended after using :func:`BPState.set_evidence`.
         """
         if initialize_states:
-            self._inner.propagate_all_vars(self._alpha, self._clear_beliefs)
-        self._inner.propagate_loopy_step(it, self._alpha, self._clear_beliefs)
+            self._inner.propagate_all_vars(alpha, clear_beliefs)
+        self._inner.propagate_loopy_step(it, alpha, clear_beliefs)
 
     def bp_acyclic(
         self,
@@ -336,7 +338,7 @@ class BPState:
         """
         return self._inner.get_belief_from_var(var, factor)
 
-    def propagate_var(self, var: str):
+    def propagate_var(self, var: str, alpha: float = 0.0, clear_beliefs: bool = True):
         """Run belief propagation on variable var.
 
         This fetches beliefs from adjacent factors, computes the var
@@ -348,7 +350,7 @@ class BPState:
             Identifier of the variable.
 
         """
-        return self._inner.propagate_var(var, self._alpha, self._clear_beliefs)
+        return self._inner.propagate_var(var, alpha, clear_beliefs)
 
     def propagate_factor(self, factor: str):
         """Run belief propagation on the given factor.

--- a/src/scalib/attacks/factor_graph.py
+++ b/src/scalib/attacks/factor_graph.py
@@ -170,12 +170,14 @@ class BPState:
         nexec: int,
         public_values: Optional[ValsAssign] = None,
         alpha: float = 0.0,
+        clear_beliefs: bool = True,
     ):
         if public_values is None:
             public_values = dict()
         self._fg = factor_graph
         self._inner = factor_graph._inner.new_bp(nexec, public_values)
         self._alpha = alpha
+        self._clear_beliefs = clear_beliefs
 
     @property
     def fg(self) -> FactorGraph:
@@ -224,8 +226,8 @@ class BPState:
             Recommended after using :func:`BPState.set_evidence`.
         """
         if initialize_states:
-            self._inner.propagate_all_vars(self._alpha)
-        self._inner.propagate_loopy_step(it, self._alpha)
+            self._inner.propagate_all_vars(self._alpha, self._clear_beliefs)
+        self._inner.propagate_loopy_step(it, self._alpha, self._clear_beliefs)
 
     def bp_acyclic(
         self,
@@ -346,7 +348,7 @@ class BPState:
             Identifier of the variable.
 
         """
-        return self._inner.propagate_var(var, self._alpha)
+        return self._inner.propagate_var(var, self._alpha, self._clear_beliefs)
 
     def propagate_factor(self, factor: str):
         """Run belief propagation on the given factor.

--- a/src/scalib_ext/scalib-py/src/factor_graph.rs
+++ b/src/scalib_ext/scalib-py/src/factor_graph.rs
@@ -243,13 +243,15 @@ impl BPState {
         let edge_id = self.get_edge_named(var, factor)?;
         distr2py(py, self.get_inner().get_belief_from_var(edge_id))
     }
-    pub fn propagate_var(&mut self, var: &str, alpha: f64) -> PyResult<()> {
+    pub fn propagate_var(&mut self, var: &str, alpha: f64, clear_beliefs: bool) -> PyResult<()> {
         let var_id = self.get_var(var)?;
-        self.get_inner_mut().propagate_var(var_id, alpha);
+        self.get_inner_mut()
+            .propagate_var(var_id, alpha, clear_beliefs);
         Ok(())
     }
-    pub fn propagate_all_vars(&mut self, alpha: f64) -> PyResult<()> {
-        self.get_inner_mut().propagate_all_vars(alpha);
+    pub fn propagate_all_vars(&mut self, alpha: f64, clear_beliefs: bool) -> PyResult<()> {
+        self.get_inner_mut()
+            .propagate_all_vars(alpha, clear_beliefs);
         Ok(())
     }
     pub fn propagate_factor_all(&mut self, factor: &str) -> PyResult<()> {
@@ -300,8 +302,9 @@ impl BPState {
             .propagate_factor(factor_id, dest.as_slice(), clear_incoming);
         Ok(())
     }
-    pub fn propagate_loopy_step(&mut self, n_steps: u32, alpha: f64) {
-        self.get_inner_mut().propagate_loopy_step(n_steps, alpha);
+    pub fn propagate_loopy_step(&mut self, n_steps: u32, alpha: f64, clear_beliefs: bool) {
+        self.get_inner_mut()
+            .propagate_loopy_step(n_steps, alpha, clear_beliefs);
     }
     pub fn graph(&self) -> FactorGraph {
         FactorGraph {

--- a/src/scalib_ext/scalib-py/src/factor_graph.rs
+++ b/src/scalib_ext/scalib-py/src/factor_graph.rs
@@ -243,13 +243,13 @@ impl BPState {
         let edge_id = self.get_edge_named(var, factor)?;
         distr2py(py, self.get_inner().get_belief_from_var(edge_id))
     }
-    pub fn propagate_var(&mut self, var: &str) -> PyResult<()> {
+    pub fn propagate_var(&mut self, var: &str, alpha: f64) -> PyResult<()> {
         let var_id = self.get_var(var)?;
-        self.get_inner_mut().propagate_var(var_id);
+        self.get_inner_mut().propagate_var(var_id, alpha);
         Ok(())
     }
-    pub fn propagate_all_vars(&mut self) -> PyResult<()> {
-        self.get_inner_mut().propagate_all_vars();
+    pub fn propagate_all_vars(&mut self, alpha: f64) -> PyResult<()> {
+        self.get_inner_mut().propagate_all_vars(alpha);
         Ok(())
     }
     pub fn propagate_factor_all(&mut self, factor: &str) -> PyResult<()> {
@@ -300,8 +300,8 @@ impl BPState {
             .propagate_factor(factor_id, dest.as_slice(), clear_incoming);
         Ok(())
     }
-    pub fn propagate_loopy_step(&mut self, n_steps: u32) {
-        self.get_inner_mut().propagate_loopy_step(n_steps);
+    pub fn propagate_loopy_step(&mut self, n_steps: u32, alpha: f64) {
+        self.get_inner_mut().propagate_loopy_step(n_steps, alpha);
     }
     pub fn graph(&self) -> FactorGraph {
         FactorGraph {

--- a/src/scalib_ext/scalib/src/sasca/belief_propagation.rs
+++ b/src/scalib_ext/scalib/src/sasca/belief_propagation.rs
@@ -210,7 +210,7 @@ impl BPState {
         // underflow (or denormalization).
         // This is guaranteed as long as min_proba > var_degree * MIN_POSITIVE
         let var = self.graph.edges[edge].var;
-        if alpha == 0.0 {
+        if alpha == 0.0 || !self.belief_from_var[edge].is_full() {
             self.belief_from_var[edge].reset();
             self.belief_from_var[edge] =
                 Distribution::divide_reg(&self.var_state[var], &self.belief_to_var[edge]);

--- a/src/scalib_ext/scalib/src/sasca/belief_propagation.rs
+++ b/src/scalib_ext/scalib/src/sasca/belief_propagation.rs
@@ -259,29 +259,31 @@ impl BPState {
         let dest: Vec<_> = self.graph.factor(factor).edges.keys().cloned().collect();
         self.propagate_factor(factor, dest.as_slice(), false);
     }
-    pub fn propagate_from_var_all(&mut self, var: VarId, alpha: f64) {
+    pub fn propagate_from_var_all(&mut self, var: VarId, alpha: f64, clear_beliefs: bool) {
         for i in 0..self.graph.var(var).edges.len() {
             self.propagate_from_var(self.graph.var(var).edges[i], alpha);
         }
-        for i in 0..self.graph.var(var).edges.len() {
-            self.belief_to_var[self.graph.var(var).edges[i]].reset();
+        if clear_beliefs {
+            for i in 0..self.graph.var(var).edges.len() {
+                self.belief_to_var[self.graph.var(var).edges[i]].reset();
+            }
         }
     }
-    pub fn propagate_var(&mut self, var: VarId, alpha: f64) {
+    pub fn propagate_var(&mut self, var: VarId, alpha: f64, clear_beliefs: bool) {
         self.propagate_to_var(var, false);
-        self.propagate_from_var_all(var, alpha);
+        self.propagate_from_var_all(var, alpha, clear_beliefs);
     }
-    pub fn propagate_all_vars(&mut self, alpha: f64) {
+    pub fn propagate_all_vars(&mut self, alpha: f64, clear_beliefs: bool) {
         for var_id in self.graph.range_vars() {
-            self.propagate_var(var_id, alpha);
+            self.propagate_var(var_id, alpha, clear_beliefs);
         }
     }
-    pub fn propagate_loopy_step(&mut self, n_steps: u32, alpha: f64) {
+    pub fn propagate_loopy_step(&mut self, n_steps: u32, alpha: f64, clear_beliefs: bool) {
         for _ in 0..n_steps {
             for factor_id in self.graph.range_factors() {
                 self.propagate_factor_all(factor_id);
             }
-            self.propagate_all_vars(alpha);
+            self.propagate_all_vars(alpha, clear_beliefs);
         }
     }
     pub fn propagate_acyclic(

--- a/src/scalib_ext/scalib/src/sasca/bp_compute.rs
+++ b/src/scalib_ext/scalib/src/sasca/bp_compute.rs
@@ -232,11 +232,13 @@ impl Distribution {
         let num_arr = numerator
             .value()
             .expect("update_dampen needs full dist num");
-
+        let v: f64 = self_arr.iter().sum::<f64>();
         if let Some(denom_arr) = denominator.value() {
-            azip!((x in &mut self_arr, y in &num_arr, z in &denom_arr) *x = alpha * (y/(z + MIN_PROBA)) + (1.0 - alpha)* *x)
+            let u: f64 = num_arr.iter().sum::<f64>() / denom_arr.iter().sum::<f64>();
+            azip!((x in &mut self_arr, y in &num_arr, z in &denom_arr) *x = (alpha/u) * (y/(z + MIN_PROBA)) + ((1.0 - alpha)/v) * *x)
         } else {
-            azip!((x in &mut self_arr, y in &num_arr) *x = alpha * (y) + (1.0 - alpha)* *x)
+            let u: f64 = num_arr.iter().sum::<f64>();
+            azip!((x in &mut self_arr, y in &num_arr) *x = (alpha/u) * (y) + ((1.0 - alpha)/v) * *x)
         }
     }
 

--- a/src/scalib_ext/scalib/src/sasca/bp_compute.rs
+++ b/src/scalib_ext/scalib/src/sasca/bp_compute.rs
@@ -232,15 +232,15 @@ impl Distribution {
         let num_arr = numerator
             .value()
             .expect("update_dampen needs full dist num");
-        let v_arr = self_arr.sum_axis(ndarray::Axis(1));
+        let sigma_s = &self_arr.sum_axis(ndarray::Axis(1));
+
         if let Some(denom_arr) = denominator.value() {
-            let u_arr = (&num_arr / (&denom_arr + MIN_PROBA)).sum_axis(ndarray::Axis(1));
+            let sigma_nd = (&num_arr / (&denom_arr + MIN_PROBA)).sum_axis(ndarray::Axis(1));
 
-            azip!((index (i, j), x in &mut self_arr, n in &num_arr, d in &denom_arr) *x = ((alpha / u_arr[i]) * (n / (d + MIN_PROBA))) + (((1.0 - alpha) / v_arr[i]) * *x))
+            azip!((index (i, _j), x in &mut self_arr, n in &num_arr, d in &denom_arr) *x = (alpha/sigma_nd[i]) * (n/(d+MIN_PROBA)) + (((1.0 - alpha)/sigma_s[i]) * *x));
         } else {
-            let u_arr = num_arr.sum_axis(ndarray::Axis(1));
-
-            azip!((index (i, j), x in &mut self_arr, n in &num_arr) *x = ((alpha / u_arr[i]) * (n)) + (((1.0 - alpha) / v_arr[i]) * *x))
+            let sigma_n = (&num_arr).sum_axis(ndarray::Axis(1));
+            azip!((index (i, _j), x in &mut self_arr, n in &num_arr) *x = ((alpha / sigma_n[i]) * (n)) + (((1.0 - alpha) / sigma_s[i]) * (*x)))
         }
     }
 

--- a/src/scalib_ext/scalib/src/sasca/bp_compute.rs
+++ b/src/scalib_ext/scalib/src/sasca/bp_compute.rs
@@ -1,5 +1,3 @@
-use std::f64::MIN;
-
 use super::belief_propagation::{BPError, FftPlans};
 use super::factor_graph::PublicValue;
 use super::ClassVal;
@@ -234,10 +232,12 @@ impl Distribution {
         let num_arr = numerator
             .value()
             .expect("update_dampen needs full dist num");
-        let denom_arr = denominator
-            .value()
-            .expect("update_dampen needs full dist denom");
-        azip!((x in &mut self_arr, y in &num_arr, z in &denom_arr) *x = alpha * (y/(z + MIN_PROBA)) + (1.0 - alpha)* *x);
+
+        if let Some(denom_arr) = denominator.value() {
+            azip!((x in &mut self_arr, y in &num_arr, z in &denom_arr) *x = alpha * (y/(z + MIN_PROBA)) + (1.0 - alpha)* *x)
+        } else {
+            azip!((x in &mut self_arr, y in &num_arr) *x = alpha * (y) + (1.0 - alpha)* *x)
+        }
     }
 
     pub fn dividing_full(&mut self, other: &Distribution) {

--- a/tests/test_factorgraph.py
+++ b/tests/test_factorgraph.py
@@ -918,18 +918,24 @@ def test_dampening_nochange():
     distri_b = np.array([[0.8, 0.2]])
     graph = FactorGraph(graph)
     n = 1
-    bp_state_no_dampen = BPState(graph, n)
-    bp_state_no_dampen.set_evidence("a", distri_a)
-    bp_state_no_dampen.set_evidence("b", distri_b)
-    bp_state_full_dampen = BPState(graph, n)
-    bp_state_full_dampen.set_evidence("a", distri_a)
-    bp_state_full_dampen.set_evidence("b", distri_b)
+    bp_no_dampen = BPState(graph, n)
+    bp_no_dampen.set_evidence("a", distri_a)
+    bp_no_dampen.set_evidence("b", distri_b)
+    bp_dampen = BPState(graph, n)
+    bp_dampen.set_evidence("a", distri_a)
+    bp_dampen.set_evidence("b", distri_b)
 
-    bp_state_no_dampen.bp_loopy(5, initialize_states=False)
-    bp_state_full_dampen.bp_loopy(5, initialize_states=False, alpha=1.0)
+    for v in graph.vars():
+        bp_dampen.propagate_var(v)
+        bp_no_dampen.propagate_var(v)
+    prev = bp_no_dampen.get_belief_from_var("a", "s1")
+    alpha = 0.5
+    bp_dampen.bp_loopy(1, False, alpha=alpha, clear_beliefs=False)
+    bp_no_dampen.bp_loopy(1, False, clear_beliefs=False)
+    print(bp_no_dampen.get_belief_from_var("a", "s1"))
     assert np.allclose(
-        bp_state_no_dampen.get_distribution("x"),
-        bp_state_full_dampen.get_distribution("x"),
+        ((1 - alpha) * prev + (alpha) * bp_no_dampen.get_belief_from_var("a", "s1")),
+        bp_dampen.get_belief_from_var("a", "s1"),
     )
 
 
@@ -976,31 +982,49 @@ def test_dampening_correctness():
 
     fg = FactorGraph(factor_graph)
     alpha = 0.9
-    bp_dampen = BPState(fg, 1, public_values={"IV": 0xC})
-    bp_no_dampen = BPState(fg, 1, public_values={"IV": 0xC})
+    bp_dampen = BPState(fg, 2, public_values={"IV": 0xC})
+    bp_no_dampen = BPState(fg, 2, public_values={"IV": 0xC})
     for k in fg.vars():
-        d = make_distri(16, 1)
+        d = make_distri(16, 2)
         bp_no_dampen.set_evidence(k, distribution=d)
         bp_dampen.set_evidence(k, distribution=d)
 
     for v in fg.vars():
         bp_dampen.propagate_var(v)
         bp_no_dampen.propagate_var(v)
-    prev = bp_no_dampen.get_belief_from_var("A", "P7")
-    prev2 = bp_no_dampen.get_belief_from_var("C", "P4")
-    prev3 = bp_no_dampen.get_belief_from_var("K0", "P1")
+    for v in fg.factors():
+        bp_dampen.propagate_factor(v)
+        bp_no_dampen.propagate_factor(v)
+    prevs_vars = {}
+    prevs_factors = {}
+    for factor in fg._inner.factor_names():
+        for var in fg._inner.factor_scope(factor):
+            k = (var, factor)
+            prevs_vars[k] = normalize_distr(
+                bp_no_dampen.get_belief_from_var(var, factor)
+            )
+            prevs_factors[k] = normalize_distr(
+                bp_no_dampen.get_belief_to_var(var, factor)
+            )
     bp_dampen.bp_loopy(1, False, alpha=alpha, clear_beliefs=False)
     bp_no_dampen.bp_loopy(1, False, clear_beliefs=False)
 
-    assert np.allclose(
-        ((1 - alpha) * prev + (alpha) * bp_no_dampen.get_belief_from_var("A", "P7")),
-        bp_dampen.get_belief_from_var("A", "P7"),
-    )
-    assert np.allclose(
-        ((1 - alpha) * prev2 + (alpha) * bp_no_dampen.get_belief_from_var("C", "P4")),
-        bp_dampen.get_belief_from_var("C", "P4"),
-    )
-    assert np.allclose(
-        ((1 - alpha) * prev3 + (alpha) * bp_no_dampen.get_belief_from_var("K0", "P1")),
-        bp_dampen.get_belief_from_var("K0", "P1"),
-    )
+    for factor in fg._inner.factor_names():
+        for var in fg._inner.factor_scope(factor):
+            k = (var, factor)
+            assert np.allclose(
+                (
+                    (1 - alpha) * prevs_vars[k]
+                    + (alpha)
+                    * normalize_distr(bp_no_dampen.get_belief_from_var(var, factor))
+                ),
+                bp_dampen.get_belief_from_var(var, factor),
+            )
+            assert np.allclose(
+                (
+                    (1 - alpha) * prevs_factors[k]
+                    + (alpha)
+                    * normalize_distr(bp_no_dampen.get_belief_to_var(var, factor))
+                ),
+                bp_dampen.get_belief_to_var(var, factor),
+            )

--- a/tests/test_factorgraph.py
+++ b/tests/test_factorgraph.py
@@ -904,3 +904,30 @@ def test_and_rounding_error_simple():
     bp.bp_loopy(5, initialize_states=False)
     assert (bp.get_distribution("K0") >= 0.0).all()
     assert (bp.get_distribution("K1") >= 0.0).all()
+
+
+def test_dampening_nochange():
+    graph = """
+        NC 2
+        PROPERTY s1: x = a^b
+        VAR MULTI x
+        VAR MULTI a
+        VAR MULTI b
+        """
+    distri_a = np.array([[0.6, 0.4]])
+    distri_b = np.array([[0.8, 0.2]])
+    graph = FactorGraph(graph)
+    n = 1
+    bp_state_no_dampen = BPState(graph, n)
+    bp_state_no_dampen.set_evidence("a", distri_a)
+    bp_state_no_dampen.set_evidence("b", distri_b)
+    bp_state_full_dampen = BPState(graph, n, alpha=1.0)
+    bp_state_full_dampen.set_evidence("a", distri_a)
+    bp_state_full_dampen.set_evidence("b", distri_b)
+
+    bp_state_no_dampen.bp_loopy(5, initialize_states=False)
+    bp_state_full_dampen.bp_loopy(5, initialize_states=False)
+    assert np.allclose(
+        bp_state_no_dampen.get_distribution("x"),
+        bp_state_full_dampen.get_distribution("x"),
+    )

--- a/tests/test_factorgraph.py
+++ b/tests/test_factorgraph.py
@@ -931,3 +931,135 @@ def test_dampening_nochange():
         bp_state_no_dampen.get_distribution("x"),
         bp_state_full_dampen.get_distribution("x"),
     )
+
+#TODO add clear_beliefs test
+
+def test_dampening_correctness():
+    factor_graph = """NC 16
+    VAR MULTI K0
+    VAR MULTI K1
+    VAR MULTI L1
+    VAR MULTI N1
+    VAR MULTI B
+    VAR MULTI C
+    VAR MULTI N0
+    VAR MULTI A
+    VAR MULTI L2
+    VAR MULTI L3
+    PUB SINGLE IV
+    PROPERTY P1: L1 = K0 ^ K1
+    PROPERTY P2: N1 = !K1
+    PROPERTY P3: B = N1 & IV
+    PROPERTY P4: C = B ^ K0
+    PROPERTY P5: N0 = !K0
+    PROPERTY P6: A = N0 & K1
+    PROPERTY P7: L2 = A ^ C
+    PROPERTY P8: L3 = K1 ^ C"""
+    priors = {
+        "A": [
+            0.0,
+            0.25,
+            0.25,
+            0.0,
+            0.25,
+            0.0,
+            0.0,
+            0.0,
+            0.25,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ],
+        "C": [
+            0.0,
+            0.0,
+            0.0,
+            0.1666666667,
+            0.0,
+            0.1666666667,
+            0.1666666667,
+            0.0,
+            0.0,
+            0.1666666667,
+            0.1666666667,
+            0.0,
+            0.1666666667,
+            0.0,
+            0.0,
+            0.0,
+        ],
+        "L1": [
+            0.0,
+            0.0,
+            0.0,
+            0.1666666667,
+            0.0,
+            0.1666666667,
+            0.1666666667,
+            0.0,
+            0.0,
+            0.1666666667,
+            0.1666666667,
+            0.0,
+            0.1666666667,
+            0.0,
+            0.0,
+            0.0,
+        ],
+        "L2": [
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.25,
+            0.0,
+            0.0,
+            0.0,
+            0.25,
+            0.0,
+            0.25,
+            0.25,
+            0.0,
+        ],
+        "L3": [
+            0.0,
+            0.0,
+            0.0,
+            0.1666666667,
+            0.0,
+            0.1666666667,
+            0.1666666667,
+            0.0,
+            0.0,
+            0.1666666667,
+            0.1666666667,
+            0.0,
+            0.1666666667,
+            0.0,
+            0.0,
+            0.0,
+        ],
+    }
+    fg = FactorGraph(factor_graph)
+    bp_dampen = BPState(
+        fg, 1, public_values={"IV": 0xC}, alpha=0.9, clear_beliefs=False
+    )
+    bp_no_dampen = BPState(fg, 1, public_values={"IV": 0xC}, clear_beliefs=False)
+    for k, v in priors.items():
+        bp_no_dampen.set_evidence(k, distribution=np.array([v]))
+        bp_dampen.set_evidence(k, distribution=np.array([v]))
+    for i in range(5):
+        bp_no_dampen.bp_loopy(1, False)
+        print(bp_no_dampen.debug())
+    # bp_no_dampen.propagate_factor("P7")
+    # print(bp_no_dampen.get_belief_to_var("A", "P7"))
+    # print(bp_no_dampen.get_belief_from_var("C", "P7"))
+    # print(bp_dampen.get_distribution("K0"))
+    assert False


### PR DESCRIPTION
Dampening [MWJ99](https://arxiv.org/pdf/1301.6725.pdf) is a technique used to reduce oscillations in loopy belief propagation. It was shown in [PP19](https://link.springer.com/chapter/10.1007/978-3-030-30530-7_7) to be effective in performing SASCAs 

