### PR TITLE
Fix BPState property

### DIFF
--- a/src/scalib/attacks/factor_graph.py
+++ b/src/scalib/attacks/factor_graph.py
@@ -179,7 +179,7 @@ class BPState:
     @property
     def fg(self) -> FactorGraph:
         """The associated factor graph."""
-        self._fg
+        return self._fg
 
     def set_evidence(self, var: str, distribution: Optional[npt.NDArray[np.float64]]):
         r"""Sets prior distribution of a variable.


### PR DESCRIPTION
Missing return, calling BPState.fg returns None otherwise