### PR TITLE
Make threadpool creation lazy.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Not released
 * Fix numerical underflow in ``BPState`` when multiple traces are used.
 * Fix missing import in ``MultiLDA``.
 * Run ``BPState`` methods on the threadpool.
+* Make threadpool initalization lazy -- makes SCALib play more nicely with ``ProcessPoolExecutor``.
 
 v0.5.3 (2023/02/21)
 -------------------

--- a/src/scalib/config/threading.py
+++ b/src/scalib/config/threading.py
@@ -15,7 +15,20 @@ class ThreadPool:
 
     def __init__(self, n_threads):
         self.n_threads = n_threads
-        self.pool = _scalib_ext.ThreadPool(n_threads)
+        self._pool = None
+
+    @property
+    def pool(self):
+        # We initialize the true threadpool lazily for 2 reasons:
+        # - It avoids creating threads when importing SCALib, which reduces
+        # import time and, more importantly, prevents bugs with the usage of
+        # subprocesses (such as with concurrent.futures.ProcessPoolExecutor),
+        # since the POSIX API does not allow fork'ing after threadds have been
+        # created.
+        # - It generally improves performance when the threadpool is not actually used.
+        if self._pool is None:
+            self._pool = _scalib_ext.ThreadPool(self.n_threads)
+        return self._pool
 
 
 def _default_num_threads():

--- a/src/scalib/postprocessing/rankestimation.py
+++ b/src/scalib/postprocessing/rankestimation.py
@@ -79,7 +79,8 @@ def rank_nbin(costs, key, nbins, method="hist"):
         Method used to estimate the rank. Can be the following:
 
         * "hist": using histograms (default).
-        * "ntl": using NTL library, allows better precision.
+        * "naive": enumerate possible keys (very slow).
+        * "histbignum": using NTL library, allows better precision.
 
     Returns
     -------


### PR DESCRIPTION
This avoids bugs where the default threadpool is created, then the process forks (e.g. MultiprocessPool), since forking and threads don't mix in POSIX.
We now only create the rayon pool when it is first used. This will not solve all bugs, but we cannot do much better (that's a Python interpreter bug -- https://bugs.python.org/issue46464).