### PR TITLE
Misc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Not released
 ------------
 
 * Fix ``Distribution`` size bug in belief propagation computation (#102).
+* Do not include debug symbols in release builds (makes wheel much smaller).
 
 v0.5.4 (2023/04/26)
 -------------------

--- a/src/scalib/metrics/ttest.py
+++ b/src/scalib/metrics/ttest.py
@@ -149,10 +149,15 @@ class Ttest:
         """
         nl, nsl = l.shape
         nx = x.shape[0]
-        if not (nx == nl):
+        if nx != nl:
             raise ValueError(f"Expected x with shape ({nl},)")
-        if not (nsl == self._ns):
-            raise Exception(f"Expected second dim of l to have size {self._ns}.")
+        if nsl != self._ns:
+            raise ValueError(f"Expected second dim of l to have size {self._ns}.")
+        if not l.flags["C_CONTIGUOUS"]:
+            raise ValueError(
+                "Expected l to be a contiguous (C memory order) array. "
+                "Use np.ascontiguous to change memory representation."
+            )
 
         with scalib.utils.interruptible():
             self._ttest.update(l, x, get_config())

--- a/src/scalib_ext/Cargo.toml
+++ b/src/scalib_ext/Cargo.toml
@@ -7,6 +7,3 @@ members = [
     "scalib-py"
 ]
 resolver = "2"
-
-[profile.release]
-debug = true

--- a/tests/test_ttest.py
+++ b/tests/test_ttest.py
@@ -112,3 +112,20 @@ def test_ttest_d6():
     ttest.fit_u(traces, labels)
     t = ttest.get_ttest()
     assert np.allclose(t_ref, t, rtol=1e-3)
+
+
+def test_ttest_data_transpose():
+    ns = 100
+    d = 1
+    nc = 2
+    n = 200
+
+    m = np.random.randint(0, 2, (nc, ns))
+    traces = np.asfortranarray(np.random.randint(0, 10, (n, ns), dtype=np.int16))
+    labels = np.random.randint(0, nc, n, dtype=np.uint16)
+    traces += m[labels]
+
+    t_ref = reference(traces, labels, d)
+    ttest = Ttest(ns, 1)
+    with pytest.raises(ValueError):
+        ttest.fit_u(traces, labels)


### PR DESCRIPTION
- Do not include debug symbols in release builds (makes wheel much smaller).
- Ttest: do not crash on non-contiguous arrays