### PR TITLE
Fix NaN results from underflows

### DIFF
--- a/src/scalib_ext/scalib/src/sasca/belief_propagation.rs
+++ b/src/scalib_ext/scalib/src/sasca/belief_propagation.rs
@@ -645,11 +645,6 @@ fn factor_add<'a>(
                 if acc_fft_init {
                     acc_fft *= &fft_tmp;
                 } else {
-                    if *negated_var {
-                        for x in fft_tmp.iter_mut() {
-                            *x = 1.0 / *x;
-                        }
-                    }
                     acc_fft.assign(&fft_tmp);
                     acc_fft_init = true;
                 }

--- a/src/scalib_ext/scalib/src/sasca/belief_propagation.rs
+++ b/src/scalib_ext/scalib/src/sasca/belief_propagation.rs
@@ -578,9 +578,7 @@ fn factor_add<'a>(
             return vec![uniform_template; dest.len()].into_iter();
         } else {
             // Single uniform op, only compute for that one.
-            for ((e_idx, e), negated_var) in
-                factor.edges.values().enumerate().zip(negated_vars.iter())
-            {
+            for (e, negated_var) in factor.edges.values().zip(negated_vars.iter()) {
                 if e != e_dest {
                     let negate = !(dest_negated ^ negated_var);
                     belief_from_var[*e].fft_to(
@@ -629,11 +627,7 @@ fn factor_add<'a>(
                     plans,
                     *negated_var,
                 );
-                if *negated_var {
-                    for x in fft_e.iter_mut() {
-                        *x = 1.0 / *x;
-                    }
-                }
+
                 dest_fft.push(fft_e);
             } else {
                 belief_from_var[*e].fft_to(
@@ -645,11 +639,7 @@ fn factor_add<'a>(
                 );
 
                 if acc_fft_init {
-                    if *negated_var {
-                        acc_fft /= &fft_tmp;
-                    } else {
-                        acc_fft *= &fft_tmp;
-                    }
+                    acc_fft *= &fft_tmp;
                 } else {
                     if *negated_var {
                         for x in fft_tmp.iter_mut() {
@@ -682,11 +672,7 @@ fn factor_add<'a>(
                     }
                 }
                 let idx = factor.edges.get_index_of(&dest[i]).unwrap();
-                if !negated_vars[idx] {
-                    for x in res.iter_mut() {
-                        *x = 1.0 / *x;
-                    }
-                }
+
                 let mut acc = uniform_template.clone();
                 acc.ifft(
                     res.view_mut(),

--- a/src/scalib_ext/scalib/src/sasca/bp_compute.rs
+++ b/src/scalib_ext/scalib/src/sasca/bp_compute.rs
@@ -139,11 +139,15 @@ impl Distribution {
         self.multiply_inner(factors, false);
     }
 
-    pub fn multiply_reg<'a>(&mut self, factors: impl Iterator<Item = &'a Distribution>) {
+    pub fn multiply_norm<'a>(&mut self, factors: impl Iterator<Item = &'a Distribution>) {
         self.multiply_inner(factors, true);
     }
 
-    fn multiply_inner<'a>(&mut self, factors: impl Iterator<Item = &'a Distribution>, reg: bool) {
+    fn multiply_inner<'a>(
+        &mut self,
+        factors: impl Iterator<Item = &'a Distribution>,
+        normalize: bool,
+    ) {
         for factor in factors {
             assert_eq!(self.shape.1, factor.shape.1);
             if self.multi & factor.multi {
@@ -166,7 +170,7 @@ impl Distribution {
                         // We therefore compute the maximum at every iteration,
                         // and correct to keep the maximum at 1. at the next
                         // iteration.
-                        if reg {
+                        if normalize {
                             let mut max_proba = 1.0f64;
                             for d in d.axis_iter(ndarray::Axis(0)) {
                                 let norm_factor = 1.0 / max_proba;
@@ -204,7 +208,7 @@ impl Distribution {
             }
             // Now we'll make to sum equal one to avoid underflows or overflows in the long run, and keep the exposed probas nice.
             // Just multiply, don't add anything, underflows are taken care of above.
-            if reg {
+            if normalize {
                 self.normalize();
             }
         }
@@ -233,6 +237,33 @@ impl Distribution {
         );
         return res;
     }
+
+    pub fn divide_norm(state: &Distribution, div: &Distribution) -> Self {
+        let mut res = Self {
+            multi: state.multi | div.multi,
+            shape: (std::cmp::max(state.shape.0, div.shape.0), state.shape.1),
+            value: DistrRepr::Uniform,
+        };
+        assert!(res.shape == state.shape || state.shape == (1, res.shape.1));
+        assert!(res.shape == div.shape || div.shape == (1, res.shape.1));
+        let one = ndarray::Array2::ones((1, 1));
+        let (vst, vdiv) = match (&state.value, &div.value) {
+            (DistrRepr::Uniform, DistrRepr::Uniform) => {
+                return res;
+            }
+            (DistrRepr::Uniform, DistrRepr::Full(v)) => (&one, v),
+            (DistrRepr::Full(v), DistrRepr::Uniform) => (v, &one),
+            (DistrRepr::Full(vst), DistrRepr::Full(vdiv)) => (vst, vdiv),
+        };
+        res.value = DistrRepr::Full(
+            Zip::from(vst.broadcast((res.shape.0, vst.dim().1)).unwrap())
+                .and_broadcast(vdiv)
+                .map_collect(|vst, vdiv| *vst / (*vdiv)),
+        );
+        res.normalize(); //todo optimize
+        return res;
+    }
+
     pub fn dividing_full(&mut self, other: &Distribution) {
         match (&mut self.value, &other.value) {
             (DistrRepr::Full(div), DistrRepr::Full(st)) => {
@@ -275,10 +306,14 @@ impl Distribution {
         mut dest: ArrayViewMut2<Complex<f64>>,
         fft_scratch: &mut [Complex<f64>],
         plans: &FftPlans,
+        negated: bool,
     ) {
         if let DistrRepr::Full(v) = &self.value {
             for (distr, mut dest) in v.outer_iter().zip(dest.outer_iter_mut()) {
                 input_scratch.copy_from_slice(distr.as_slice().unwrap());
+                if negated {
+                    negate_slice_distr(input_scratch);
+                }
                 plans
                     .r2c
                     .process_with_scratch(input_scratch, dest.as_slice_mut().unwrap(), fft_scratch)
@@ -291,6 +326,7 @@ impl Distribution {
         mut input: ArrayViewMut2<Complex<f64>>,
         fft_scratch: &mut [Complex<f64>],
         plans: &FftPlans,
+        negated: bool,
     ) {
         self.ensure_full();
         let mut v = self.value_mut().unwrap();
@@ -303,6 +339,9 @@ impl Distribution {
                     fft_scratch,
                 )
                 .unwrap();
+            if negated {
+                negate_slice_distr(dest.as_slice_mut().unwrap());
+            }
         }
     }
     pub fn is_full(&self) -> bool {
@@ -383,8 +422,10 @@ impl Distribution {
             let (sum, min) = d
                 .iter()
                 .fold((0.0f64, 0.0f64), |(sum, min), x| (sum + x, min.min(*x)));
-            let offset = -min + MIN_PROBA;
-            let norm_f = 1.0 / (sum + offset * d.len() as f64);
+
+            let norm_f = (1.0 - MIN_PROBA * (d.len() as f64)) / (sum - (min * (d.len() as f64)));
+            let offset = -min + (MIN_PROBA / norm_f);
+
             d.mapv_inplace(|x| (x + offset) * norm_f);
         })
     }
@@ -528,6 +569,16 @@ impl Distribution {
     }
 }
 
+fn negate_slice_distr(a: &mut [f64]) {
+    let n = if a.len() % 2 == 0 {
+        (a.len() / 2) - 1
+    } else {
+        a.len() / 2
+    };
+    for i in 1..=n {
+        a.swap(i, a.len() - i);
+    }
+}
 /// Walsh-Hadamard transform (non-normalized).
 fn slice_wht(a: &mut [f64]) {
     // The speed of this can be much improved, with the following techiques

--- a/src/scalib_ext/scalib/src/sasca/bp_compute.rs
+++ b/src/scalib_ext/scalib/src/sasca/bp_compute.rs
@@ -544,7 +544,7 @@ impl Distribution {
     }
 }
 
-/// Let `a` represent the distribution of a variable `x`, update a to make it represent the distribution of  `(a.len()+1)-x`
+/// Let `a` represent the distribution of a variable `x`, update a to make it represent the distribution of  `(a.len()-1)-x`
 fn negate_slice_distr(a: &mut [f64]) {
     let n = if a.len() % 2 == 0 {
         (a.len() / 2) - 1

--- a/tests/test_factorgraph.py
+++ b/tests/test_factorgraph.py
@@ -1099,22 +1099,34 @@ def test_ADD5():
     nc = 256
     n = 10
     graph = f"""NC {nc}
-    VAR MULTI a0
-    VAR MULTI x0
-    VAR MULTI x1
+    VAR MULTI x
+    VAR MULTI y
+    VAR MULTI z
 
 
 
-    PROPERTY F0: a0 = x0 + x1
+    PROPERTY F0: z = x + y
     """
     fg = FactorGraph(graph)
     for _ in range(50):
         bp = BPState(fg, n)
 
-        bp.set_evidence("x0", make_distri(nc, n))
-        bp.set_evidence("a0", make_distri(nc, n))
+        x_distri = make_distri(nc, n)
+        z_distri = make_distri(nc, n)
+        bp.set_evidence("x", x_distri)
+        bp.set_evidence("z", z_distri)
+
+        y_distri_ref = np.zeros(x_distri.shape)
+
+        for x in range(nc):
+            for z in range(nc):
+                y_distri_ref[:, (z - x) % nc] += x_distri[:, x] * z_distri[:, z]
+
+        y_distri_ref = (y_distri_ref.T / np.sum(y_distri_ref, axis=1)).T
+
         bp.bp_loopy(50, initialize_states=False)
-        for x in ["x0", "x1", "a0"]:
+        assert np.allclose(y_distri_ref, bp.get_distribution("y"))
+        for x in ["x", "y", "z"]:
             print(bp.get_distribution(x))
             assert not np.isnan(bp.get_distribution(x)).any()
 

--- a/tests/test_factorgraph.py
+++ b/tests/test_factorgraph.py
@@ -395,7 +395,7 @@ def test_ADD():
     Test ADD between distributions
     """
     nc = 241
-    n = 1
+    n = 4
     distri_x = make_distri(nc, n)
     distri_y = make_distri(nc, n)
 
@@ -1012,6 +1012,31 @@ def test_ADD3():
     for x in ["x0", "x1", "a0"]:
         print(bp_state.get_distribution(x))
         assert not np.isnan(bp_state.get_distribution(x)).any()
+
+
+def test_ADD4():
+    nc = 256
+    n = 10
+    graph = f"""NC {nc}
+    VAR MULTI a0
+    VAR MULTI x0
+    VAR MULTI x1
+
+
+
+    PROPERTY F0: a0 = x0 + x1
+    """
+    fg = FactorGraph(graph)
+    for _ in range(50):
+        bp = BPState(fg, n)
+
+        bp.set_evidence("x0", make_distri(nc, n))
+        bp.set_evidence("x1", make_distri(nc, n))
+        bp.set_evidence("a0", make_distri(nc, n))
+        bp.bp_loopy(50, initialize_states=False)
+        for x in ["x0", "x1", "a0"]:
+            print(bp.get_distribution(x))
+            assert not np.isnan(bp.get_distribution(x)).any()
 
 
 def test_mix_single_multi():

--- a/tests/test_factorgraph.py
+++ b/tests/test_factorgraph.py
@@ -394,15 +394,15 @@ def test_ADD():
     """
     Test ADD between distributions
     """
-    nc = 251
-    n = 4
+    nc = 241
+    n = 1
     distri_x = make_distri(nc, n)
     distri_y = make_distri(nc, n)
 
     graph = f"""
         # some comments
         NC {nc}
-        PROPERTY z = x+y
+        PROPERTY F0: z = x+y
         VAR MULTI z
         VAR MULTI x
         VAR MULTI y
@@ -415,6 +415,50 @@ def test_ADD():
     bp_state.set_evidence("y", distri_y)
 
     bp_state.bp_loopy(1, True)
+    distri_z = bp_state.get_distribution("z")
+
+    distri_z_ref = np.zeros(distri_z.shape)
+    msg = np.zeros(distri_z.shape)
+
+    for x in range(nc):
+        for y in range(nc):
+            distri_z_ref[:, (x + y) % nc] += distri_x[:, x] * distri_y[:, y]
+
+    distri_z_ref = (distri_z_ref.T / np.sum(distri_z_ref, axis=1)).T
+    assert np.allclose(distri_z_ref, distri_z)
+
+
+def test_ADD2():
+    """
+    Test ADD between distributions
+    """
+    nc = 16
+    n = 1
+    distri_x = np.zeros((n, nc))  # make_distri(nc, n)
+    distri_y = np.zeros((n, nc))  # make_distri(nc, n)
+
+    distri_x[:, 0] = 1.0
+    distri_y[:, 0] = 1.0
+
+    graph = f"""
+        # some comments
+        NC {nc}
+        PROPERTY F: z = x+y
+        VAR MULTI z
+        VAR MULTI x
+        VAR MULTI y
+
+        """
+
+    graph = FactorGraph(graph)
+    bp_state = BPState(graph, n)
+    bp_state.set_evidence("x", distri_x)
+    bp_state.set_evidence("y", distri_y)
+    print(bp_state.debug())
+    bp_state.bp_loopy(1, True)
+    print(bp_state.debug())
+    bp_state.bp_loopy(10, False)
+    print(bp_state.debug())
     distri_z = bp_state.get_distribution("z")
 
     distri_z_ref = np.zeros(distri_z.shape)
@@ -936,6 +980,38 @@ def test_manytraces():
     distri_y_ref = distri_y_ref / distri_y_ref.sum(axis=1, keepdims=True)
 
     assert np.allclose(distri_y_ref, distri_y, rtol=1e-5, atol=1e-19)
+
+
+def test_ADD3():
+    nc = 13
+    graph = f"""NC {nc}
+    TABLE SUB = [0, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    VAR MULTI a0
+    VAR MULTI x0
+    VAR MULTI x1
+
+
+
+    PROPERTY F0: a0 = x0 + x1
+    """
+    a0_distr = np.array(
+        [[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+    )
+    x0_distr = np.array(
+        [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]]
+    )
+    x1_distr = np.array(
+        [[0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
+    )
+    fg = FactorGraph(graph)
+    bp_state = BPState(fg, 1)
+    bp_state.set_evidence("x0", x0_distr)
+    bp_state.set_evidence("x1", x1_distr)
+    bp_state.set_evidence("a0", a0_distr)
+    bp_state.bp_loopy(50, initialize_states=False)
+    for x in ["x0", "x1", "a0"]:
+        print(bp_state.get_distribution(x))
+        assert not np.isnan(bp_state.get_distribution(x)).any()
 
 
 def test_mix_single_multi():

--- a/tests/test_factorgraph.py
+++ b/tests/test_factorgraph.py
@@ -1095,7 +1095,6 @@ def test_mix_single_multi():
             assert np.allclose(d, d2, rtol=1e-5, atol=1e-19)
 
 
-
 def test_ADD5():
     nc = 256
     n = 10
@@ -1119,6 +1118,7 @@ def test_ADD5():
             print(bp.get_distribution(x))
             assert not np.isnan(bp.get_distribution(x)).any()
 
+
 def test_clear_beliefs():
     graph = """
     NC 2
@@ -1136,4 +1136,3 @@ def test_clear_beliefs():
     assert bp.get_belief_from_var("x", "s1") is not None
     assert bp.get_belief_from_var("a", "s1") is not None
     assert bp.get_belief_from_var("b", "s1") is not None
-

--- a/tests/test_factorgraph.py
+++ b/tests/test_factorgraph.py
@@ -1093,3 +1093,27 @@ def test_mix_single_multi():
         d2 = sasca2.get_distribution("s")
         if d is not None:
             assert np.allclose(d, d2, rtol=1e-5, atol=1e-19)
+
+
+def test_ADD5():
+    nc = 256
+    n = 10
+    graph = f"""NC {nc}
+    VAR MULTI a0
+    VAR MULTI x0
+    VAR MULTI x1
+
+
+
+    PROPERTY F0: a0 = x0 + x1
+    """
+    fg = FactorGraph(graph)
+    for _ in range(50):
+        bp = BPState(fg, n)
+
+        bp.set_evidence("x0", make_distri(nc, n))
+        bp.set_evidence("a0", make_distri(nc, n))
+        bp.bp_loopy(50, initialize_states=False)
+        for x in ["x0", "x1", "a0"]:
+            print(bp.get_distribution(x))
+            assert not np.isnan(bp.get_distribution(x)).any()


### PR DESCRIPTION
Some situations can cause numerical underflows - the following fixes mitigate those occurances