### PR TITLE
Quantization function

### DIFF
--- a/docs/source/api_ref.rst
+++ b/docs/source/api_ref.rst
@@ -10,6 +10,7 @@ API Reference
    :toctree: api
 
    metrics
+   preprocessing
    modeling
    attacks
    postprocessing

--- a/src/scalib/__init__.py
+++ b/src/scalib/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "preprocessing",
     "config",
     "attacks",
     "metrics",

--- a/src/scalib/preprocessing/__init__.py
+++ b/src/scalib/preprocessing/__init__.py
@@ -1,0 +1,15 @@
+r"""
+This module contains usefull preprocessing to manipulate side channel traces..
+
+.. currentmodule:: scalib.preprocessing
+
+.. autosummary::
+   :toctree:
+   :recursive:
+   :nosignatures:
+
+   Quantizer
+"""
+__all__ = ["Quantizer"]
+
+from .quantization import Quantizer

--- a/src/scalib/preprocessing/__init__.py
+++ b/src/scalib/preprocessing/__init__.py
@@ -8,8 +8,9 @@ This module contains usefull preprocessing to manipulate side channel traces..
    :recursive:
    :nosignatures:
 
+   QuantFitMethod
    Quantizer
 """
-__all__ = ["Quantizer"]
+__all__ = ["QuantFitMethod", "Quantizer"]
 
-from .quantization import Quantizer
+from .quantization import QuantFitMethod, Quantizer

--- a/src/scalib/preprocessing/quantization.py
+++ b/src/scalib/preprocessing/quantization.py
@@ -6,7 +6,13 @@ class QUANTIZER:
         The quantizer estimates a shift and scale that minimize the loss due to the rounding operation.
 
     .. math::
-        \mathrm{Quantize}(X) = (x - \mathrm{Shift}) \times \mathrm{Scale}
+        \mathrm{Quantize}( x) = (x - \mathrm{Shift}) \cdot \mathrm{Scale}
+
+    The shift and scale are computed using `n` samples as
+
+    .. math::
+        \mathrm{Shift} = \frac{1}{2} (\max_{i=1}^n x_i + \min_{i=1}^n x_i) \qquad and \qquad  \mathrm{Scale} = \frac{2^{14}}{\max_{i=1}^n x_i - \min_{i=1}^n x_i}.
+
 
     Parameters
     ----------
@@ -24,9 +30,9 @@ class QUANTIZER:
     >>> # 500 traces of 200 points
     >>> noisy_traces : np.ndarray[np.float64] = np.random.randn(500,200)
     >>> quantizer = QUANTIZER(200, np.zeros(200),np.ones(200))
-    >>> snr.fit_shift_scale(noisy_traces)
+    >>> quantizer.fit_shift_scale(noisy_traces)
     >>> quantized_traces : np.ndarray[np.int16] = quantizer.quantize(noisy_traces)
-    >>> # Can be reused directly 5000 new traces for instance
+    >>> # Can be reused directly on 5000 new traces for instance
     >>> noisy_traces : np.ndarray[np.float64] = np.random.randn(5000,200)
     >>> quantized_traces : np.ndarray[np.int16] = quantizer.quantize(noisy_traces)
     """

--- a/src/scalib/preprocessing/quantization.py
+++ b/src/scalib/preprocessing/quantization.py
@@ -25,39 +25,50 @@ class Quantizer:
 
     Examples
     --------
-    >>> from scalib.preprocessing import QUANTIZER
+    >>> from scalib.preprocessing import Quantizer
     >>> import numpy as np
     >>> # 500 traces of 200 points
-    >>> noisy_traces : np.ndarray[np.float64] = np.random.randn(500,200)
-    >>> quantizer = QUANTIZER(200, np.zeros(200),np.ones(200))
-    >>> quantizer.fit_shift_scale(noisy_traces)
-    >>> quantized_traces : np.ndarray[np.int16] = quantizer.quantize(noisy_traces)
+    >>> traces : np.ndarray[np.float64] = np.random.randn(500,200)
+    >>> quantizer = Quantizer.fit_shift_scale(traces)
+    >>> quantized_traces : np.ndarray[np.int16] = quantizer.quantize(traces)
     >>> # Can be reused directly on 5000 new traces for instance
-    >>> noisy_traces : np.ndarray[np.float64] = np.random.randn(5000,200)
-    >>> quantized_traces : np.ndarray[np.int16] = quantizer.quantize(noisy_traces)
+    >>> traces : np.ndarray[np.float64] = np.random.randn(5000,200)
+    >>> quantized_traces : np.ndarray[np.int16] = quantizer.quantize(traces)
     """
 
-    def __init__(
-        self, ns: int, shift: np.ndarray[np.float64], scale: np.ndarray[np.float64]
-    ):
-        self._ns = ns
+    def __init__(self, shift: np.ndarray[np.float64], scale: np.ndarray[np.float64]):
         self._shift = shift
         self._scale = scale
 
-    def fit_shift_scale(self, noisy_traces: np.ndarray[np.float64]) -> None:
-        r"""Updates the shift and scale estimation from sample of `noisy_traces`
-        This method may be called multiple times.
+    @classmethod
+    def fit_shift_scale(cls, traces: np.ndarray[np.float64], gaussian=True):
+        r"""Compute the shift and scale estimation from sample of `traces`
+        This class method returns an instance of Quantizer with the corresponding shift and scale.
 
         Parameters
         ----------
-        noisy_traces : array_like, np.float64
+        traces : array_like, np.float64
             Array that contains the traces to estimate the shift and scale in the quantization. The array must
             be of dimension `(n, ns)`
+        gaussian : boolean
+            A boolean parameter set to True by default. In this case, the min and max are estimated under the Gaussianity assumption.
         """
 
         # Max/Min Centering and Multiplication by a constant prior to quantization to avoid information loss via rounding error
-        max: np.ndarray[np.float64] = np.amax(noisy_traces, axis=0)
-        min: np.ndarray[np.float64] = np.amin(noisy_traces, axis=0)
+        max: np.ndarray[np.float64] = np.amax(traces, axis=0)
+        min: np.ndarray[np.float64] = np.amin(traces, axis=0)
+
+        if gaussian:
+            # Gaussian Methods
+            mean: np.ndarray[np.float64] = np.amax(traces, axis=0)
+            std = np.std(traces, axis=0, ddof=1)
+
+            # Conservative confidence interval.
+            g_min = mean - 7 * std
+            g_max = mean + 7 * std
+
+            max = np.maximum(max, g_max)
+            min = np.minimum(min, g_min)
 
         # Derive shift and scale accordingly to center the traces
         shift: np.ndarray[np.float64] = (max + min) / 2
@@ -66,20 +77,36 @@ class Quantizer:
             2**14
         ) / width  # 2**14 instead of 2**15 as a safety margin.
 
-        # Update the parameter
-        self._shift = shift
-        self._scale = scale
+        # Create Quantizer
+        quantizer = cls(shift, scale)
 
-    def quantize(self, noisy_traces: np.ndarray[np.float64]) -> np.ndarray[np.int16]:
-        r"""Quantize the noisy traces provide in `noisy_traces`
+        return quantizer
+
+    def quantize(
+        self, traces: np.ndarray[np.float64], clip: bool = False
+    ) -> np.ndarray[np.int16]:
+        r"""Quantize the traces provide in `traces`
 
         Parameters
         ----------
-        noisy_traces : array_like, np.float64
+        traces : array_like, np.float64
             Array that contains the traces to be quantized into int16. The array must
             be of dimension `(n, ns)`
+        clip : bool
+            Boolean to bypass the overflow check prior to quantization and clip the overflowing values to the boundaries.
+            By default it is set to False.
         """
-        quantized_traces: np.ndarray[np.int16] = (
-            (noisy_traces - self._shift) * self._scale
-        ).astype(np.int16)
+        adjusted_traces: np.ndarray[np.float64] = (traces - self._shift) * self._scale
+
+        if clip:
+            adjusted_traces = np.clip(adjusted_traces, -(2**15), 2**15 - 1)
+        else:
+            if (adjusted_traces > 2**15 - 1).any() or (
+                adjusted_traces < -(2**15)
+            ).any():
+                raise ValueError(
+                    "Overflow detected in the quantization. Update shift and scale more precisely to avoid the error. "
+                )
+
+        quantized_traces: np.ndarray[np.int16] = (adjusted_traces).astype(np.int16)
         return quantized_traces

--- a/src/scalib/preprocessing/quantization.py
+++ b/src/scalib/preprocessing/quantization.py
@@ -2,12 +2,11 @@ import numpy as np
 
 
 class QUANTIZER:
-    r"""Quantize a side channel traces given as as float into int16.
-        The quantizer evaluates the minimum and maximum value of the traces at each point to estimate a shift and
-        scale that minimize the loss due to rounding.
+    r"""Quantize a side channel traces given as an array of float into an array of int16.
+        The quantizer estimates a shift and scale that minimize the loss due to the rounding operation.
 
     .. math::
-        \mathrm{Quantize}(X) = (x - \mathrm{Shift}) * \mathrm{Scale}
+        \mathrm{Quantize}(X) = (x - \mathrm{Shift}) \times \mathrm{Scale}
 
     Parameters
     ----------
@@ -47,7 +46,7 @@ class QUANTIZER:
         ----------
         noisy_traces : array_like, np.float64
             Array that contains the traces to estimate the shift and scale in the quantization. The array must
-            be of dimension `(n, ns)
+            be of dimension `(n, ns)`
         """
 
         # Max/Min Centering and Multiplication by a constant prior to quantization to avoid information loss via rounding error
@@ -72,7 +71,7 @@ class QUANTIZER:
         ----------
         noisy_traces : array_like, np.float64
             Array that contains the traces to be quantized into int16. The array must
-            be of dimension `(n, ns)
+            be of dimension `(n, ns)`
         """
         quantized_traces: np.ndarray[np.int16] = (
             (noisy_traces - self._shift) * self._scale

--- a/src/scalib/preprocessing/quantization.py
+++ b/src/scalib/preprocessing/quantization.py
@@ -19,7 +19,7 @@ class Quantizer:
     .. math::
         \mathrm{Quantize}( x) = (x - \mathrm{Shift}) \cdot \mathrm{Scale}
 
-    The shift and scale are computed for each point using `n` samples as
+    The shift and scale are vectors whose j-th coordinate is computed using `n` samples as
 
     .. math::
         \mathrm{Shift}_j = \frac{1}{2} (\max_{i=1}^n x_{i,j} + \min_{i=1}^n x_{i,j}) \qquad and \qquad  \mathrm{Scale}_j = \frac{2^{14}}{\max_{i=1}^n x_{i,j} - \min_{i=1}^n x_{i,j}}.

--- a/src/scalib/preprocessing/quantization.py
+++ b/src/scalib/preprocessing/quantization.py
@@ -1,0 +1,80 @@
+import numpy as np
+
+
+class QUANTIZER:
+    r"""Quantize a side channel traces given as as float into int16.
+        The quantizer evaluates the minimum and maximum value of the traces at each point to estimate a shift and
+        scale that minimize the loss due to rounding.
+
+    .. math::
+        \mathrm{Quantize}(X) = (x - \mathrm{Shift}) * \mathrm{Scale}
+
+    Parameters
+    ----------
+    ns : int
+        Number of samples in a single trace.
+    shift : np.ndarray[np.float64]
+        The value to shift every traces.
+    scale : np.ndarray[np.float64]
+        The value to scale every traces.
+
+    Examples
+    --------
+    >>> from scalib.preprocessing import QUANTIZER
+    >>> import numpy as np
+    >>> # 500 traces of 200 points
+    >>> noisy_traces : np.ndarray[np.float64] = np.random.randn(500,200)
+    >>> quantizer = QUANTIZER(200, np.zeros(200),np.ones(200))
+    >>> snr.fit_shift_scale(noisy_traces)
+    >>> quantized_traces : np.ndarray[np.int16] = quantizer.quantize(noisy_traces)
+    >>> # Can be reused directly 5000 new traces for instance
+    >>> noisy_traces : np.ndarray[np.float64] = np.random.randn(5000,200)
+    >>> quantized_traces : np.ndarray[np.int16] = quantizer.quantize(noisy_traces)
+    """
+
+    def __init__(
+        self, ns: int, shift: np.ndarray[np.float64], scale: np.ndarray[np.float64]
+    ):
+        self._ns = ns
+        self._shift = shift
+        self._scale = scale
+
+    def fit_shift_scale(self, noisy_traces: np.ndarray[np.float64]) -> None:
+        r"""Updates the shift and scale estimation from sample of `noisy_traces`
+        This method may be called multiple times.
+
+        Parameters
+        ----------
+        noisy_traces : array_like, np.float64
+            Array that contains the traces to estimate the shift and scale in the quantization. The array must
+            be of dimension `(n, ns)
+        """
+
+        # Max/Min Centering and Multiplication by a constant prior to quantization to avoid information loss via rounding error
+        max: np.ndarray[np.float64] = np.amax(noisy_traces, axis=0)
+        min: np.ndarray[np.float64] = np.amin(noisy_traces, axis=0)
+
+        # Derive shift and scale accordingly to center the traces
+        shift: np.ndarray[np.float64] = (max + min) / 2
+        width: np.ndarray[np.float64] = (max - min) / 2
+        scale: np.ndarray[np.float64] = (
+            2**14
+        ) / width  # 2**14 instead of 2**15 as a safety margin.
+
+        # Update the parameter
+        self._shift = shift
+        self._scale = scale
+
+    def quantize(self, noisy_traces: np.ndarray[np.float64]) -> np.ndarray[np.int16]:
+        r"""Quantize the noisy traces provide in `noisy_traces`
+
+        Parameters
+        ----------
+        noisy_traces : array_like, np.float64
+            Array that contains the traces to be quantized into int16. The array must
+            be of dimension `(n, ns)
+        """
+        quantized_traces: np.ndarray[np.int16] = (
+            (noisy_traces - self._shift) * self._scale
+        ).astype(np.int16)
+        return quantized_traces

--- a/src/scalib/preprocessing/quantization.py
+++ b/src/scalib/preprocessing/quantization.py
@@ -19,11 +19,16 @@ class Quantizer:
     .. math::
         \mathrm{Quantize}( x) = (x - \mathrm{Shift}) \cdot \mathrm{Scale}
 
-    The shift and scale are computed using `n` samples as
+    The shift and scale are computed for each point using `n` samples as
 
     .. math::
-        \mathrm{Shift} = \frac{1}{2} (\max_{i=1}^n x_i + \min_{i=1}^n x_i) \qquad and \qquad  \mathrm{Scale} = \frac{2^{14}}{\max_{i=1}^n x_i - \min_{i=1}^n x_i}.
+        \mathrm{Shift}_j = \frac{1}{2} (\max_{i=1}^n x_{i,j} + \min_{i=1}^n x_{i,j}) \qquad and \qquad  \mathrm{Scale}_j = \frac{2^{14}}{\max_{i=1}^n x_{i,j} - \min_{i=1}^n x_{i,j}}.
 
+    Warning
+    ^^^^^^^
+
+    The quantization procedure operates pointwise: each point is shifted and scaled by a different value.
+    As a consequence the quantized version of the trace probably does not look like its non quantized version.
 
     Parameters
     ----------

--- a/src/scalib/preprocessing/quantization.py
+++ b/src/scalib/preprocessing/quantization.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-class QUANTIZER:
+class Quantizer:
     r"""Quantize a side channel traces given as an array of float into an array of int16.
         The quantizer estimates a shift and scale that minimize the loss due to the rounding operation.
 

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -1,0 +1,18 @@
+import pytest
+from scalib.preprocessing import Quantizer
+import numpy as np
+
+
+def test_quantizer():
+    fitting_traces: np.ndarray[np.float64] = np.random.randn(500, 200)
+    traces: np.ndarray[np.float64] = np.random.randn(5000, 200)
+
+    quantizer = Quantizer.fit_shift_scale(fitting_traces, False)
+    quantized_traces: np.ndarray[np.int16] = quantizer.quantize(traces)
+
+    quantized_traces: np.ndarray[np.int16] = quantizer.quantize(8 * traces, True)
+    with pytest.raises(ValueError):
+        quantized_traces: np.ndarray[np.int16] = quantizer.quantize(8 * traces)
+
+    quantizer = Quantizer.fit_shift_scale(fitting_traces, True)
+    quantized_traces: np.ndarray[np.int16] = quantizer.quantize(traces)

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -16,3 +16,9 @@ def test_quantizer():
 
     quantizer = Quantizer.fit(fitting_traces, QuantFitMethod.BOUNDS)
     quantized_traces: np.ndarray[np.int16] = quantizer.quantize(traces)
+
+    reconstruction: np.ndarray[np.float64] = (
+        quantized_traces / quantizer._scale + quantizer._shift
+    ).astype(np.float64)
+    reconstruction_error: np.float64 = np.linalg.norm(traces - reconstruction, axis=1)
+    assert (reconstruction_error <= 10**-2).all()

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -7,12 +7,12 @@ def test_quantizer():
     fitting_traces: np.ndarray[np.float64] = np.random.randn(500, 200)
     traces: np.ndarray[np.float64] = np.random.randn(5000, 200)
 
-    quantizer = Quantizer.fit_shift_scale(fitting_traces, False)
+    quantizer = Quantizer.fit(fitting_traces, False)
     quantized_traces: np.ndarray[np.int16] = quantizer.quantize(traces)
 
     quantized_traces: np.ndarray[np.int16] = quantizer.quantize(8 * traces, True)
     with pytest.raises(ValueError):
         quantized_traces: np.ndarray[np.int16] = quantizer.quantize(8 * traces)
 
-    quantizer = Quantizer.fit_shift_scale(fitting_traces, True)
+    quantizer = Quantizer.fit(fitting_traces, True)
     quantized_traces: np.ndarray[np.int16] = quantizer.quantize(traces)

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -1,5 +1,5 @@
 import pytest
-from scalib.preprocessing import Quantizer
+from scalib.preprocessing import Quantizer, QuantFitMethod
 import numpy as np
 
 
@@ -7,12 +7,12 @@ def test_quantizer():
     fitting_traces: np.ndarray[np.float64] = np.random.randn(500, 200)
     traces: np.ndarray[np.float64] = np.random.randn(5000, 200)
 
-    quantizer = Quantizer.fit(fitting_traces, False)
+    quantizer = Quantizer.fit(fitting_traces, QuantFitMethod.MOMENT)
     quantized_traces: np.ndarray[np.int16] = quantizer.quantize(traces)
 
     quantized_traces: np.ndarray[np.int16] = quantizer.quantize(8 * traces, True)
     with pytest.raises(ValueError):
         quantized_traces: np.ndarray[np.int16] = quantizer.quantize(8 * traces)
 
-    quantizer = Quantizer.fit(fitting_traces, True)
+    quantizer = Quantizer.fit(fitting_traces, QuantFitMethod.BOUNDS)
     quantized_traces: np.ndarray[np.int16] = quantizer.quantize(traces)


### PR DESCRIPTION
Add a preprocessing quantization function to map floating point representation of side channel traces into their int16 quantization used in SCALib. The traces are shifted and normalized so that the rounding error is limited as much as possible in the process.  This shift and scale are fitted on a few traces before first use.    