### PR TITLE
Change type of cluster distance in API to match backend

### DIFF
--- a/src/scalib/modeling/rldaclassifier.py
+++ b/src/scalib/modeling/rldaclassifier.py
@@ -156,7 +156,7 @@ class RLDAClassifier:
     def get_clustered_model(
         self,
         var: int,
-        t: int,
+        t: float,
         max_clusters: int = 10_000_000,
         store_associated_classes: bool = True,
     ) -> ClusteredModel:


### PR DESCRIPTION
The typehint of this parameter is set incorrectly to `int`, it should be `float` (as in the rust code). 