### PR TITLE
Remove py-cpuinfo dependency, roll our own implementation.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ recursive-include src/scalib_ext/ranklib *
 recursive-include src/scalib_ext/geigen *
 recursive-include src/scalib_ext/scalib *
 recursive-include src/scalib_ext/scalib-py *
+recursive-include src/scalib_ext/cpu-check *
 include src/scalib_ext/Cargo.toml
 include src/scalib_ext/Cargo.lock
 exclude src/scalib/_scalib_ext.abi3.so

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ fmt:
 	tox run -e fmt
 
 wheel_x86_64_v3:
-	SCALIB_X86_64_V3=1 CARGO_TARGET_DIR=.cargo_build_x86_64_v3 pyproject-build -m build -w -o dist/avx2
+	SCALIB_X86_64_V3=1 CARGO_TARGET_DIR=.cargo_build_x86_64_v3 pyproject-build -w -o dist/avx2
 
 wheel_local:
 	CARGO_TARGET_DIR=.cargo_build pyproject-build -w -o dist/local

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,13 +54,14 @@ autodoc_typehints = "description"
 # python path.
 autodoc_mock_imports = [
     "scalib._scalib_ext",
+    "scalib._cpu_check",
     "scalib.version",
     "scalib.build_config",
     "numpy",
     "cpuinfo",
 ]
 
-linkcheck_ignore = [r'https://mathoverflow.net/a/273060']
+linkcheck_ignore = [r"https://mathoverflow.net/a/273060"]
 
 import sys
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ zip_safe = False
 python_requires = >=3.10
 install_requires =
         numpy >=1.26.0,<3
-        py-cpuinfo~=9.0
 
 
 [options.packages.find]

--- a/src/scalib/__init__.py
+++ b/src/scalib/__init__.py
@@ -9,38 +9,21 @@ __all__ = [
     "ScalibError",
 ]
 
-import cpuinfo
 
 from .build_config import REQUIRE_X86_64_V3
-from .version import version as __version__
+from .version import version as __version__  # noqa: F401
 
-cpu = cpuinfo.get_cpu_info()
+from ._cpu_check import support_x86_64_v3
 
-X86_64_V3_FEATURES = [
-    "AVX",
-    "AVX2",
-    "BMI1",
-    "BMI2",
-    # Some features not tested, shouldn't be an issue.
-    # "f16c",
-    # "fma",
-    # "lzcnt",
-    # "movbe",
-    # "osxsave",
-]
-
-if (
-    REQUIRE_X86_64_V3
-    and cpu["arch"] == "X86_64"
-    and any(f.lower() not in cpu["flags"] for f in X86_64_V3_FEATURES)
-):
-    mf = ", ".join(f for f in X86_64_V3_FEATURES if f not in cpu["flags"])
+if REQUIRE_X86_64_V3 and not all(s for _, s in support_x86_64_v3()):
+    # mf = ", ".join(f for f in X86_64_V3_FEATURES if f not in cpu["flags"])
     raise ImportError(
         "This SCALib build requires x86-64-v3 level processor features, which "
         + "are not all supported by this CPU or OS."
         + "See https://github.com/simple-crypto/SCALib/blob/main/README.rst "
         + "for compiling a SCALib adapted to your CPU."
-        + f"(Missing features: {mf})."
+        + f"Missing features: {[f for f, a in support_x86_64_v3() if not a]}."
+        #    + f"(Missing features: {mf})."
     )
 
 from scalib._scalib_ext import ScalibError

--- a/src/scalib_ext/Cargo.lock
+++ b/src/scalib_ext/Cargo.lock
@@ -307,6 +307,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpu-check"
+version = "0.1.0"
+dependencies = [
+ "pyo3",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/scalib_ext/Cargo.toml
+++ b/src/scalib_ext/Cargo.toml
@@ -1,9 +1,4 @@
 [workspace]
 
-members = [
-    "geigen",
-    "scalib",
-    "ranklib",
-    "scalib-py"
-]
+members = ["geigen", "scalib", "ranklib", "scalib-py", "cpu-check"]
 resolver = "2"

--- a/src/scalib_ext/cpu-check/Cargo.toml
+++ b/src/scalib_ext/cpu-check/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cpu-check"
+version = "0.1.0"
+authors = ["Gaëtan Cassiers <gaetan.cassiers@uclouvain.be>"]
+edition = "2021"
+
+[lib]
+name = "cpu_check"
+crate-type = ["cdylib"]
+
+[dependencies.pyo3]
+version = "0.23.3"
+features = ["extension-module", "abi3-py310"]

--- a/src/scalib_ext/cpu-check/src/lib.rs
+++ b/src/scalib_ext/cpu-check/src/lib.rs
@@ -1,0 +1,28 @@
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn support_x86_64_v3(_py: Python) -> Vec<(&'static str, bool)> {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        vec![
+            ("avx", std::is_x86_feature_detected!("avx")),
+            ("avx2", std::is_x86_feature_detected!("avx2")),
+            ("bmi1", std::is_x86_feature_detected!("bmi1")),
+            ("bmi2", std::is_x86_feature_detected!("bmi2")),
+            ("f16c", std::is_x86_feature_detected!("f16c")),
+            ("fma", std::is_x86_feature_detected!("fma")),
+            ("lzcnt", std::is_x86_feature_detected!("lzcnt")),
+            ("movbe", std::is_x86_feature_detected!("movbe")),
+        ]
+    }
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        vec![]
+    }
+}
+
+#[pymodule]
+fn _cpu_check(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(support_x86_64_v3, m)?)?;
+    Ok(())
+}


### PR DESCRIPTION
cpuinfo was very slow to import, making "import scalib" take a noticeable amount of time, which was annoying.
We replace it with a new native library implemented in rust, that uses rust stdlib feature detection.